### PR TITLE
chore(infra): GitHub-Actions auf Node-24-Runtime anheben

### DIFF
--- a/.github/workflows/build-edge-docker.yml
+++ b/.github/workflows/build-edge-docker.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU (Multi-Platform)
         uses: docker/setup-qemu-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-pos-windows.yml
+++ b/.github/workflows/build-pos-windows.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Cloud-Pattern: keine `version:` setzen — die Action liest die pnpm-
       # Version aus dem `packageManager`-Feld der package.json.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           filter: tree:0
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
       # Fallback HEAD~1; PR: merge-base). Verhindert, dass `affected` ohne Base
       # alle ~100 Projekte baut (Runner-OOM / Exit 130). Braucht fetch-depth: 0.
       - name: Derive affected SHAs
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@v5
 
       # `--no-frozen-lockfile`, weil das committete pnpm-lock.yaml im Workbench-
       # Setup ein Snapshot des geteilten Root-Lockfiles ist (Symlink + skip-worktree,

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -31,7 +31,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           filter: tree:0
           fetch-depth: 0

--- a/.github/workflows/release-pos-windows.yml
+++ b/.github/workflows/release-pos-windows.yml
@@ -20,13 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      # bitwarden/sm-action@v2 (Node20-Runtime) statt @v3 (Node24-Runtime).
-      # Node24 ist auf GitHub-Runnern noch nicht GA → startup_failure (Run-
-      # Start ≈ Run-Ende, keine Jobs, keine Logs). v2 ist stabil.
+      # bitwarden/sm-action@v3 (Node24-Runtime). Zuvor war @v2 (Node20) gepinnt,
+      # weil @v3 bei pos-v26.6.1 einen startup_failure verursachte (Node24 auf
+      # GitHub-Runnern damals noch nicht GA → Run-Start ≈ Run-Ende, keine Jobs,
+      # keine Logs). Mit der Node-24-Erzwingung ab 2026-06-16 läuft die node20-
+      # Runtime ohnehin nicht mehr → @v3 ist der einzige tragfähige Pfad.
       - name: Bitwarden Secrets laden
-        uses: bitwarden/sm-action@v2
+        uses: bitwarden/sm-action@v3
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           base_url: https://tresor.ratke.info

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
     name: osv-scanner (SCA)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
         with:
           scan-args: |-
@@ -38,7 +38,7 @@ jobs:
     container:
       image: ghcr.io/gitleaks/gitleaks:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: gitleaks (filesystem scan)
         run: gitleaks dir . --redact --exit-code 1
 
@@ -48,7 +48,7 @@ jobs:
     container:
       image: semgrep/semgrep:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: semgrep ci
         run: |
           semgrep ci \
@@ -67,7 +67,7 @@ jobs:
       contents: read
       security-events: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Render summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Kontext

GitHub erzwingt ab **2026-06-16** die Node-24-Runtime für Actions; node20-Actions laufen danach nicht mehr. Die CI-Annotation flaggte konkret `actions/checkout@v4` und `nrwl/nx-set-shas@v4`. Dieser PR hebt **alle** node20-Actions in panary-core auf node24-fähige Majors an.

## Änderungen (nur node20 → node24)

| Action | vorher | nachher | Datei(en) |
|---|---|---|---|
| `actions/checkout` | v4 (node20) | **v6** | ci, security ×4, build-edge-docker, build-pos-windows, publish-libraries, release-pos-windows |
| `nrwl/nx-set-shas` | v4 (node20) | **v5** | ci |
| `docker/setup-buildx-action` | v3 (node20) | **v4** | build-edge-docker |
| `docker/login-action` | v3 (node20) | **v4** | build-edge-docker |
| `bitwarden/sm-action` | v2 (node20) | **v3** | release-pos-windows |

checkout-Ziel `v6` (statt v5) = aktuellste Major + konsistent mit panary-cloud (läuft bereits auf v6).

## Bewusst unverändert (bereits node24 / nicht node-basiert)

`setup-node@v6`, `pnpm/action-setup@v6`, `upload-artifact@v7`, `build-push-action@v7`, `setup-qemu-action@v4`, `rust-cache@v2.9.1` (node24), `tauri-action@v0` (node24) · `attest-build-provenance@v4` / `cosign-installer@v3` / `rust-toolchain@stable` (composite) · `osv-scanner@v2.0.2` (docker). Alle Runtimes per `action.yml` (`runs.using`) gegen die jeweilige Upstream-Version verifiziert.

**panary-cloud** ist bereits vollständig node24 (`checkout@v6`, `setup-node@v6`, `docker/*@v4/v7`, kein nx-set-shas) → **keine Änderung nötig**.

## ⚠️ bitwarden/sm-action v2 → v3

Der v2-Pin (node20) war **bewusst** gesetzt, weil @v3 bei `pos-v26.6.1` einen `startup_failure` auslöste (node24 auf Runnern damals nicht GA). Mit der Node-24-Erzwingung ist node20 ohnehin tot → v3 ist der einzige tragfähige Pfad. **Nicht im PR/CI verifizierbar** — `release-pos-windows.yml` triggert nur auf `pos-v*`-Tags, also erst beim nächsten POS-Release prüfbar.

## Verifikation

- ✅ Alle 6 Workflows parsen sauber (YAML).
- ✅ `ci.yml` (`checkout@v6` + `nx-set-shas@v5`) und `security.yml` (`checkout@v6`) laufen auf diesem PR.
- ⏳ Tag-getriggerte Workflows (`build-edge-docker` auf `v*`, `release-pos-windows` auf `pos-v*`) laufen nicht im PR — erst beim nächsten Tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)