### PR TITLE
chore(release): v26.7.10

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,7 +24,7 @@ Additional Use Grant: You may make use of the Licensed Work, provided that you m
                       (c) Using the Licensed Work for development, testing, and evaluation
                           purposes.
 
-Change Date:          2030-06-07 (Four years from the release date)
+Change Date:          2030-06-16 (Four years from the release date)
 Change License:       Apache License, Version 2.0
 
 Terms

--- a/apps/api-edge/package.json
+++ b/apps/api-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-edge",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "private": true,
   "feathers": {
     "language": "ts",

--- a/apps/pos-client/src-tauri/tauri.conf.json
+++ b/apps/pos-client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "Panary — Terminal",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "identifier": "de.panary.pos",
   "build": {
     "frontendDist": "../../../dist/apps/pos-client/browser",

--- a/libs/domains/allergens/package.json
+++ b/libs/domains/allergens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/allergens",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/apikeys/package.json
+++ b/libs/domains/apikeys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/apikeys",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/audit-events/package.json
+++ b/libs/domains/audit-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/audit-events",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/auth/package.json
+++ b/libs/domains/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/auth",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/brands/package.json
+++ b/libs/domains/brands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/brands",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/businessdays/package.json
+++ b/libs/domains/businessdays/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/businessdays",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/cloud-edges/package.json
+++ b/libs/domains/cloud-edges/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/cloud-edges",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/corporate-customers/package.json
+++ b/libs/domains/corporate-customers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/corporate-customers",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/customers/package.json
+++ b/libs/domains/customers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/customers",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/devices/package.json
+++ b/libs/domains/devices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/devices",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/discounts/package.json
+++ b/libs/domains/discounts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/discounts",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/edge-pairing/package.json
+++ b/libs/domains/edge-pairing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/edge-pairing",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/ingredients/package.json
+++ b/libs/domains/ingredients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/ingredients",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/locations/package.json
+++ b/libs/domains/locations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/locations",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/notifications/package.json
+++ b/libs/domains/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/notifications",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/opening-hour-exceptions/package.json
+++ b/libs/domains/opening-hour-exceptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/opening-hour-exceptions",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/order-interactions/package.json
+++ b/libs/domains/order-interactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/order-interactions",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/orders/package.json
+++ b/libs/domains/orders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/orders",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/pre-orders/package.json
+++ b/libs/domains/pre-orders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/pre-orders",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/pricelists/package.json
+++ b/libs/domains/pricelists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/pricelists",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/product-groups/package.json
+++ b/libs/domains/product-groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/product-groups",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/products/package.json
+++ b/libs/domains/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/products",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/receipts/package.json
+++ b/libs/domains/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/receipts",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/recipes/package.json
+++ b/libs/domains/recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/recipes",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/reservations/package.json
+++ b/libs/domains/reservations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/reservations",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/supplier-products/package.json
+++ b/libs/domains/supplier-products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/supplier-products",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/suppliers/package.json
+++ b/libs/domains/suppliers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/suppliers",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/sync/package.json
+++ b/libs/domains/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/sync",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/tenants/package.json
+++ b/libs/domains/tenants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/tenants",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/tse/package.json
+++ b/libs/domains/tse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/tse",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/user-preferences/package.json
+++ b/libs/domains/user-preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/user-preferences",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/users/package.json
+++ b/libs/domains/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/users",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/working-times/package.json
+++ b/libs/domains/working-times/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/working-times",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/domains/write-offs/package.json
+++ b/libs/domains/write-offs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/write-offs",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/shared/backend/package.json
+++ b/libs/shared/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/shared-backend",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "main": "./src/index.js",

--- a/libs/shared/common/package.json
+++ b/libs/shared/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/shared-common",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "main": "./src/index.js",

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/shared",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "exports": {

--- a/libs/shared/util-error-handling/package.json
+++ b/libs/shared/util-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panary/util-error-handling",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "type": "commonjs",
   "main": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panary-core",
-  "version": "26.7.9",
+  "version": "26.7.10",
   "license": "BSL-1.1",
   "packageManager": "pnpm@10.12.1",
   "keywords": [


### PR DESCRIPTION
## Release 26.7.10

Versions-Bump für das Connect-Tier Offline-Cache-Feature (Orders & Pre-Orders), gemergt via #31.

- **38 publishable Libs** (fixed group) 26.7.9 → 26.7.10 via `nx release version`.
- **Apps:** root `package.json`, `apps/api-edge/package.json` (APP_VERSION /health), `apps/pos-client/src-tauri/tauri.conf.json` → 26.7.10.
- **LICENSE:** BSL Change Date → 2030-06-16 (4 Jahre).

Nach Merge werden die Tags `v26.7.10` (Edge-Docker + Lib-Publish) und `pos-v26.7.10` (POS-Windows-Build) gesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)