### PR TITLE
fix(ci): Updater-Artefakte im manuellen POS-Build-Workflow deaktivieren

### DIFF
--- a/.github/workflows/build-pos-windows.yml
+++ b/.github/workflows/build-pos-windows.yml
@@ -67,6 +67,20 @@ jobs:
           fi
           echo "Angular build OK: $(ls dist/apps/pos-client/browser/ | wc -l) files"
 
+      # Seit a85ef6c steht `bundle.createUpdaterArtifacts: true` in der
+      # tauri.conf.json (Updater-Fix fuer Release pos-v26.7.14). Damit will
+      # JEDER Tauri-Build die Updater-Artefakte signieren und bricht ohne
+      # TAURI_SIGNING_PRIVATE_KEY ab. Dieser Workflow baut nur Test-Artefakte
+      # ohne Release/Updater-Manifest — der Signing-Key bleibt bewusst dem
+      # Release-Workflow vorbehalten (Least-Privilege), stattdessen wird das
+      # Updater-Artefakt hier per Config-Override deaktiviert.
+      # WICHTIG: Override als Datei statt Inline-JSON in `args` — tauri-action
+      # parst `args` mit string-argv, das die JSON-Anfuehrungszeichen als
+      # Quoting interpretiert und wegstrippt → invalides JSON beim Tauri-CLI.
+      - name: Tauri-Config-Override (Updater-Artefakte deaktivieren)
+        shell: bash
+        run: printf '%s' '{"bundle":{"createUpdaterArtifacts":false}}' > apps/pos-client/src-tauri/ci-no-updater.conf.json
+
       - name: Build Tauri (NSIS Installer)
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
@@ -74,6 +88,9 @@ jobs:
         with:
           projectPath: apps/pos-client
           tauriScript: pnpm tauri
+          # Pfad relativ zu projectPath (Tauri-CLI liest die Datei beim
+          # Argument-Parsing im Invocation-CWD, vor dem chdir nach src-tauri)
+          args: --config src-tauri/ci-no-updater.conf.json
 
       - name: Upload Installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-pos-windows.yml
+++ b/.github/workflows/build-pos-windows.yml
@@ -88,9 +88,12 @@ jobs:
         with:
           projectPath: apps/pos-client
           tauriScript: pnpm tauri
-          # Pfad relativ zu projectPath (Tauri-CLI liest die Datei beim
-          # Argument-Parsing im Invocation-CWD, vor dem chdir nach src-tauri)
-          args: --config src-tauri/ci-no-updater.conf.json
+          # Absoluter Pfad zwingend: tauri-action fuehrt `pnpm tauri build`
+          # mit CWD im Repo-Root aus (nicht in projectPath), und das Tauri-CLI
+          # liest die --config-Datei beim Argument-Parsing relativ zum CWD.
+          # Ein projectPath-relativer Pfad scheitert mit os error 3
+          # (beobachtet in Run 28625013514).
+          args: --config ${{ github.workspace }}/apps/pos-client/src-tauri/ci-no-updater.conf.json
 
       - name: Upload Installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Problem

Seit a85ef6c (`createUpdaterArtifacts: true` für den Release-Updater, pos-v26.7.14) verlangt jeder Tauri-Build den Signing-Key. Der manuelle Workflow „Build POS (Windows)" (Artifact-only, kein Release) übergibt keinen `TAURI_SIGNING_PRIVATE_KEY` und schlug daher immer fehl (z. B. Run 28612706685).

## Fix (Least-Privilege)

Updater-Artefakte werden nur in diesem Workflow per Config-Override deaktiviert — der Signing-Key bleibt dem Release-Workflow vorbehalten:

- Step schreibt `ci-no-updater.conf.json` mit `{"bundle":{"createUpdaterArtifacts":false}}`
- Übergabe via `args: --config ${{ github.workspace }}/apps/pos-client/src-tauri/ci-no-updater.conf.json`

Zwei Fallstricke, die die Umsetzung bestimmen:
1. **Kein Inline-JSON in `args`** — tauri-action parst mit string-argv, das die JSON-Quotes wegstrippt
2. **Absoluter Pfad Pflicht** — tauri-action führt `pnpm tauri build` im Repo-Root aus (nicht in projectPath), Run 28625013514 scheiterte mit projectPath-relativem Pfad

## Verifikation

✅ Run [28625398687](https://github.com/panary/panary-core/actions/runs/28625398687) grün, Artefakt `panary-pos-client-windows` (NSIS-Installer) hochgeladen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)