### PR TITLE
fix(security): OSV-Scan wieder grün — adm-zip 0.6.0, serde_with 3.21.0, anyhow 1.0.104

### DIFF
--- a/apps/pos-client/src-tauri/Cargo.lock
+++ b/apps/pos-client/src-tauri/Cargo.lock
@@ -1543,7 +1543,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3344,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3704,7 +3704,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -4827,7 +4827,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -4851,7 +4851,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4907,7 +4907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -4919,7 +4919,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4931,21 +4931,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4954,7 +4941,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -4999,7 +4986,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -5013,30 +5000,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5527,7 +5496,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/apps/pos-client/src-tauri/Cargo.lock
+++ b/apps/pos-client/src-tauri/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"

--- a/apps/pos-client/src-tauri/osv-scanner.toml
+++ b/apps/pos-client/src-tauri/osv-scanner.toml
@@ -77,10 +77,6 @@ id = "RUSTSEC-2025-0098"  # unic-ucd-version
 reason = "unmaintained Unicode-Crate (kein Fix); transitive Build-Abhängigkeit im Tauri-Stack."
 
 [[IgnoredVulns]]
-id = "RUSTSEC-2026-0190"  # anyhow
-reason = "anyhow 1.0.102 — fixbar auf 1.0.103. Wird per Dependabot-Cargo-Update nachgezogen; bis dahin bewusst ignoriert."
-
-[[IgnoredVulns]]
 id = "RUSTSEC-2026-0194"  # quick-xml (DoS: quadratische Attribut-Duplikat-Prüfung)
 reason = "quick-xml 0.39.4 — Fix erst in 0.41.0, kein 0.39.x-Backport. Einziger Parent plist 1.9.0 (neueste Version, via tauri 2) verlangt strikt ^0.39.2 → nicht isoliert bumpbar. Exposure: plist parst nur eigene Bundle-Metadaten (Info.plist) zur Build-/Bundle-Zeit, kein Angreifer-kontrolliertes XML zur POS-Laufzeit. Re-evaluieren sobald plist quick-xml ≥0.41 erlaubt."
 

--- a/package.json
+++ b/package.json
@@ -202,7 +202,8 @@
       "undici": "^7.28.0",
       "@babel/core": "^7.29.6",
       "form-data": "^4.0.6",
-      "piscina": "^5.2.0"
+      "piscina": "^5.2.0",
+      "adm-zip": "^0.6.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,7 @@ overrides:
   '@babel/core': ^7.29.6
   form-data: ^4.0.6
   piscina: ^5.2.0
+  adm-zip: ^0.6.0
 
 importers:
 
@@ -4210,9 +4211,9 @@ packages:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
 
-  adm-zip@0.5.10:
-    resolution: {integrity: sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==}
-    engines: {node: '>=6.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -11476,7 +11477,7 @@ snapshots:
       '@module-federation/managers': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/third-party-dts-extractor': 2.5.1
-      adm-zip: 0.5.10
+      adm-zip: 0.6.0
       ansi-colors: 4.1.3
       isomorphic-ws: 5.0.0(ws@8.21.0)
       node-schedule: 2.1.1
@@ -13945,7 +13946,7 @@ snapshots:
 
   address@2.0.3: {}
 
-  adm-zip@0.5.10: {}
+  adm-zip@0.6.0: {}
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
## Problem

Der nächtliche **Security Scan** (`security.yml`, Job `osv-scanner`) schlägt seit dem **2026-07-16** mit Exit-Code 1 fehl. Kein Code-Regress — zwei Advisories wurden neu veröffentlicht und trafen auf unveränderte Lockfiles.

| Advisory | Paket | CVSS | Ökosystem |
|---|---|---|---|
| GHSA-7gcf-g7xr-8hxj | `serde_with` 3.20.0 | 5.1 Medium | crates.io |
| GHSA-xcpc-8h2w-3j85 (CVE-2026-39244) | `adm-zip` 0.5.10 | 7.5 High | npm |

### adm-zip

`Buffer.alloc()` wird auf die *ungeprüfte* uncompressed-size aus dem ZIP-Central-Directory gesetzt — noch vor der CRC-Prüfung. Ein ~120-Byte-ZIP kann ~4 GB deklarieren (Amplifikation >33 Mio:1) → Memory-Exhaustion-DoS. Betroffen sind alle Extraktionspfade (`readFile`, `extractAllTo`, …).

**Exposure hier: keine.** `adm-zip` kommt rein transitiv über `@nx/angular` → `@nx/module-federation` → `@module-federation/dts-plugin` als devDependency. Module Federation wird im Repo nirgends verwendet — der Code läuft nie. Das Gate blockt trotzdem korrekt am Lockfile-Eintrag.

### serde_with

Panic im `KeyValueMap`-Serializer (`Vec::with_capacity(len - 1)` ohne Validierung der Key-Felder). Transitiv über `tauri-utils`.

## Änderungen

1. **`adm-zip: ^0.6.0`** als `pnpm.overrides` in `package.json` (panary-core hat keine `pnpm-workspace.yaml`). Pendant-Override in panary-cloud — synchron halten.
2. **`serde_with` 3.20.0 → 3.21.0** via `cargo update -p serde_with`.
3. **`anyhow` 1.0.102 → 1.0.104** + Entfernung des `RUSTSEC-2026-0190`-Ignores aus `osv-scanner.toml` (war explizit als Zwischenlösung markiert).

## Geprüft, nicht angenommen

- **Cooldown:** `adm-zip 0.6.0` ist seit 2026-07-10 publiziert, liegt also außerhalb des 7-Tage-`minimumReleaseAge` → kein Lockfile-Rückfall.
- **Breaking Changes 0.6.0** (`extractEntryTo` behält Unterverzeichnisse statt zu flatten, engines ≥14, `utimes` best-effort) berühren den dts-plugin-Aufrufpfad nicht.
- **`windows-*`-Crates verschwinden aus `Cargo.lock`** — das ist kein Downgrade, sondern eine Dedup: `iana-time-zone` erlaubt eine windows-core-Range und fällt auf die ohnehin vorhandene 0.61.2 zusammen. Für den Windows-POS-Build unkritisch; `cargo metadata --locked` bleibt grün.
- **`RUSTSEC-2024-0429` (glib)** bleibt bewusst als Ignore drin, obwohl der Scanner ihn als „unused" meldet — aktuell matcht die GHSA-Alias `GHSA-wrw7-89jp-8q8g`, die Vulnerability besteht fort.

## Verifikation

Lokal mit **osv-scanner 2.3.8** — identische Version wie CI:

```
No issues found
Exit-Code: 0
```

Zusätzlich `cargo metadata --locked` grün (Lockfile-Konsistenz ohne Build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)