### PR TITLE
fix(security): OSV-Sweep 2026-07-22 — Security-Scan wieder grün

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,11 +173,12 @@
       "esbuild": "^0.28.1",
       "serialize-javascript": "^7.0.5",
       "diff": "^8.0.4",
-      "fast-uri": "^3.1.2",
+      "fast-uri": "^3.1.4",
       "ip-address": "^10.2.0",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
       "brace-expansion@1": "^1.1.13",
       "brace-expansion@2": "^2.0.2",
+      "brace-expansion@5": "^5.0.7",
       "yaml": "^2.8.3",
       "follow-redirects": "^1.16.0",
       "uuid": "^14.0.0",
@@ -195,7 +196,7 @@
       "ajv@8": "^8.18.0",
       "@tootallnate/once": "^2.0.1",
       "koa@3": "^3.1.2",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.0",
       "vite": "^7.3.5",
       "webpack-dev-server": "^5.2.5",
       "http-proxy-middleware": "^3.0.7",
@@ -203,7 +204,9 @@
       "@babel/core": "^7.29.6",
       "form-data": "^4.0.6",
       "piscina": "^5.2.0",
-      "adm-zip": "^0.6.0"
+      "adm-zip": "^0.6.0",
+      "immutable": "^5.1.8",
+      "@hono/node-server": "^2.0.10"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,11 +18,12 @@ overrides:
   esbuild: ^0.28.1
   serialize-javascript: ^7.0.5
   diff: ^8.0.4
-  fast-uri: ^3.1.2
+  fast-uri: ^3.1.4
   ip-address: ^10.2.0
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   brace-expansion@1: ^1.1.13
   brace-expansion@2: ^2.0.2
+  brace-expansion@5: ^5.0.7
   yaml: ^2.8.3
   follow-redirects: ^1.16.0
   uuid: ^14.0.0
@@ -40,7 +41,7 @@ overrides:
   ajv@8: ^8.18.0
   '@tootallnate/once': ^2.0.1
   koa@3: ^3.1.2
-  js-yaml: ^4.2.0
+  js-yaml: ^4.3.0
   vite: ^7.3.5
   webpack-dev-server: ^5.2.5
   http-proxy-middleware: ^3.0.7
@@ -49,6 +50,8 @@ overrides:
   form-data: ^4.0.6
   piscina: ^5.2.0
   adm-zip: ^0.6.0
+  immutable: ^5.1.8
+  '@hono/node-server': ^2.0.10
 
 importers:
 
@@ -1706,9 +1709,9 @@ packages:
   '@harperfast/extended-iterable@1.0.3':
     resolution: {integrity: sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -4711,8 +4714,8 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5724,8 +5727,8 @@ packages:
     resolution: {integrity: sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==}
     engines: {node: '>=18.2.0'}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6157,9 +6160,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  immutable@5.1.6:
-    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
-
   immutable@5.1.9:
     resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
@@ -6516,10 +6516,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -10941,7 +10937,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -11148,7 +11144,7 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -11654,7 +11650,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -14315,7 +14311,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14680,7 +14676,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.3
 
@@ -15762,7 +15758,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       tslib: 2.8.1
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:
@@ -16251,8 +16247,6 @@ snapshots:
   image-size@0.5.5:
     optional: true
 
-  immutable@5.1.6: {}
-
   immutable@5.1.9: {}
 
   import-fresh@3.3.1:
@@ -16731,10 +16725,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -17322,7 +17312,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
@@ -17398,7 +17388,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -17698,7 +17688,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
       buffer: 5.7.1
       call-bind-apply-helpers: 1.0.2
       chalk: 4.1.2
@@ -18788,7 +18778,7 @@ snapshots:
   sass@1.101.0:
     dependencies:
       chokidar: 5.0.0
-      immutable: 5.1.6
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## Problem

Der nächtliche **Security Scan** ist seit dem **2026-07-21** rot (`osv-scanner`, Exit-Code 1) — 6 Befunde über 5 Pakete.

Kein Code-Regress: die Advisories stammen vom **23.06.–19.07.** und wurden Mitte Juli gebündelt in die OSV-Datenbank importiert. Sie trafen auf ein unverändertes Lockfile — deshalb waren die PR-Läufe am 20.07. noch grün.

## Behoben

| Paket | Bump | Advisory | CVSS |
|---|---|---|---|
| `immutable` | 5.1.6 → **5.1.9** | GHSA-v56q-mh7h-f735 + GHSA-xvcm-6775-5m9r | **8.7** |
| `brace-expansion` | 5.0.6 → **5.0.7** | GHSA-3jxr-9vmj-r5cp | 7.7 |
| `fast-uri` | 3.1.3 → **3.1.4** | GHSA-v2hh-gcrm-f6hx | 7.5 |
| `js-yaml` | 4.2.0 → **4.3.0** | GHSA-52cp-r559-cp3m | 7.5 |
| `@hono/node-server` | 1.19.14 → **2.0.11** | GHSA-frvp-7c67-39w9 + GHSA-9mqv-5hh9-4cgg | 5.9 / 5.3 |

**`immutable`** (8.7) ist der schwerste: List-Operationen mit Indizes in `[2³⁰, 2³¹)` laufen in eine *unabfangbare* Endlosschleife bzw. Heap-Exhaustion — ein 43-Byte-Request genügt.

**`brace-expansion`** ist ein Fund am Rande: die bestehenden Selektoren deckten nur `@1` und `@2` ab, die **v5-Linie lief ungepatcht mit**. Neuer Selektor `brace-expansion@5`.

## Cross-Major-Override: `@hono/node-server` 1.x → 2.x

Ein Fix in der 1.x-Linie existiert nicht — 2.x ist die einzige gepatchte Linie. Das Paket kommt rein transitiv über `@modelcontextprotocol/sdk` → `@angular/cli` (devDependency); der SDK deklariert `^1.19.9`, der Override verletzt diese Range also bewusst.

Präzedenz im Repo: `js-yaml ^4.2.0` (cross-major 3→4) aus dem Juni-Sweep.

**Exposure ist null**: dev-only, läuft in keinem Build und in keinem Container; die Lücke ist zusätzlich Windows-only. Betroffen wäre allenfalls `ng mcp` (Angular-CLI-MCP-Server für KI-Assistenten). Falls der bricht, ist die Alternative ein `osv-scanner.toml`-Ignore mit derselben Begründung.

Floor auf `^2.0.10`, weil 2.0.0–2.0.9 zusätzlich GHSA-9mqv-5hh9-4cgg (WebSocket-Memory-Leak) tragen.

## Nebenbefund

`panary-core` hat **keine `pnpm-workspace.yaml`** und damit auch keine `minimumReleaseAge`-Karenz — die liegt nur in `panary-cloud` und im Workbench-Root. `fast-uri 3.1.4` (3 Tage alt) und `@hono/node-server 2.0.11` waren hier deshalb ohne Cooldown-Konflikt installierbar; in panary-cloud brauchte derselbe Bump eine befristete Ausnahme. Ob Core die Härtung nachziehen soll, ist eine eigene Entscheidung.

## Verifikation

Lokal mit **osv-scanner 2.3.8** — identische Version wie CI:

```
No issues found
Exit-Code: 0
```

Keine neuen Peer-Konflikte (die `typescript`/`mongodb`-Warnungen sind vorbestehend).

## Gegenstück

panary/panary-cloud#20 — dort 43 Befunde, gleiche Ursache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
