### PR TITLE
fix(api-edge): NUL-Separator im Outbox-Coalescing als Escape-Sequenz schreiben

### DIFF
--- a/apps/api-edge/src/workers/cloud-sync-scheduler.worker.ts
+++ b/apps/api-edge/src/workers/cloud-sync-scheduler.worker.ts
@@ -390,14 +390,14 @@ const coalescePendingEntries = async (
   }
   const newestPerEntity = new Map<string, string>()
   for (const sibling of siblings) {
-    const key = `${sibling.service} ${sibling.entityId}`
+    const key = `${sibling.service}\u0000${sibling.entityId}`
     const current = newestPerEntity.get(key)
     if (!current || sibling._id > current) newestPerEntity.set(key, sibling._id)
   }
   const survivors: SyncOutboxEntry[] = []
   const superseded: Array<{ _id: string; newestId: string }> = []
   for (const entry of entries) {
-    const newestId = newestPerEntity.get(`${entry.service} ${entry.entityId}`)
+    const newestId = newestPerEntity.get(`${entry.service}\u0000${entry.entityId}`)
     if (newestId && newestId > entry._id) {
       superseded.push({ _id: entry._id, newestId })
     } else {


### PR DESCRIPTION
## Problem

`coalescePendingEntries` (Sync-Outbox-Coalescing, `cloud-sync-scheduler.worker.ts`) baut den Gruppierungs-Schlüssel pro Entity aus `service` + `entityId` mit einem **Leerzeichen** als Trenner:

```ts
const key = `${sibling.service} ${sibling.entityId}`   // Leerzeichen als Trenner
```

Enthält `service` oder `entityId` selbst ein Leerzeichen, sind zwei eigentlich verschiedene Entities nicht mehr eindeutig unterscheidbar (`"a b" + "c"` kollidiert mit `"a" + "b c"`). Das Coalescing könnte dann Outbox-Einträge fälschlich als dieselbe Entity zusammenfassen und einen davon zu Unrecht als `superseded` markieren.

## Fix

Trenner auf das NUL-Zeichen (U+0000, im Code als ``-Escape, unten als `<NUL>` dargestellt) umgestellt — kann in keiner Service-/Entity-ID vorkommen und macht den Schlüssel damit kollisionsfrei:

```ts
const key = `${sibling.service}<NUL>${sibling.entityId}`   // <NUL> = U+0000
```

Beide Aufbaustellen (Sibling-Map + Survivor-Prüfung) angepasst. Reiner Härtungs-Fix, keine Verhaltensänderung im Normalfall.

## Kontext

Der ursprüngliche Commit (`14b3547`, 2026-07-07) lag ungepusht auf dem lokalen `main` und wurde nie in einen PR überführt. Er gehört zur Coalescing-Logik aus `a106409` (ADR `documentation/sync-outbox-echo-coalescing.md`). Keine Spec nimmt den Separator-Charakter an → keine Test-Anpassung nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
