### PR TITLE
docs(arch): auf die LikeC4-Pflegeregel im Cloud-Repo verweisen

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -120,5 +120,35 @@ generated: { by: <actor>, at: <ISO-8601> }
 6. **Externe Integration:** Protokoll, Konfiguration, Fehlerbehandlung
 7. **Breaking Changes:** Was ändert sich, Migrations-Schritte
 
+---
+
+## 7. Architekturmodell (LikeC4) — liegt in panary-cloud
+
+Das LikeC4-Modell bildet das **Gesamtsystem** ab, also auch Edge, POS, Drucker und TSE. Es
+liegt aus technischen Gründen im Nachbar-Repo (`panary-cloud/docs/architecture/c4/`) —
+LikeC4 löst Referenzen nur innerhalb eines Verzeichnisbaums auf, ein repo-übergreifender
+Landschafts-View braucht deshalb einen Eigentümer. Entscheidung:
+`panary-cloud/docs/adr/0028-likec4-architecture-as-code.md`.
+
+**Konsequenz für Arbeit in diesem Repo:** Berührt eine Änderung hier ein Element, eine
+Grenze, ein Fremdsystem oder einen Ablauf, gehört die Modellpflege dazu — der Commit landet
+dann in `panary-cloud`, nicht hier. Typische Auslöser:
+
+- neuer Deployable oder Hintergrund-Worker mit Außenwirkung
+- geänderter Sync-Pfad (Endpunkte, Allowlists, Transport) oder Pairing-Flow
+- neuer öffentlich erreichbarer Endpunkt am Edge → `#public`
+- Fiskalisierung: echter TSE-Adapter statt Simulator → `#planned`/`#partial` fällt weg
+- neue externe Integration (Drucker-Protokoll, Provider, Discovery)
+
+**Nicht** modellrelevant: Schema-Felder, Lint-/Style-Regeln, reines Refactoring, neue
+Migrationen ohne Strukturwirkung.
+
+> Das CI-Gate in `panary-cloud` (`arch:validate`) prüft nur, ob das Modell parst — **nicht**,
+> ob es noch stimmt. Gegen Drift schützt allein diese Regel.
+
+Vollständige Regeln: `panary-cloud/.claude/rules/documentation.md` §7.
+
+---
+
 **Sprache:** Deutsch. **Dateinamen:** `kebab-case`. Keine Doku-Dateien außerhalb von `/docs`
 (Ausnahmen: `README.md`, `CLAUDE.md`, `.claude/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,12 @@ Ordner-Index + `docs/index.md` + `docs/log.md` im gleichen Commit.
 **Pflicht-Dokumentation bei:** neuem Feature/Domain, Architekturänderung (→ ADR), neuem
 Service, komplexer Business-Logik, Setup/Migration, externer Integration, Breaking Changes.
 
+**Architekturmodell (LikeC4):** Das Modell des Gesamtsystems (inkl. Edge, POS, Drucker, TSE)
+liegt in `panary-cloud/docs/architecture/c4/`. Berührt eine Änderung hier ein Element, eine
+Grenze, ein Fremdsystem oder einen Ablauf (Sync-Pfad, Pairing, neuer `#public`-Endpunkt,
+echter TSE-Adapter), wird es mitgepflegt — der Commit landet dann in `panary-cloud`.
+Regeln: `.claude/rules/documentation.md` §7.
+
 ---
 
 # 7. Tool-Strategie


### PR DESCRIPTION
Ergänzt `.claude/rules/documentation.md` um **§7** und einen Einzeiler in `CLAUDE.md` §6.

## Warum hier

Das LikeC4-Modell bildet das Gesamtsystem ab — auch **Edge, POS, Drucker und TSE**, also genau das, was in diesem Repo entwickelt wird. Es liegt aber in `panary-cloud/docs/architecture/c4/`, weil LikeC4 Referenzen nur innerhalb eines Verzeichnisbaums auflöst und ein repo-übergreifender Landschafts-View deshalb einen Eigentümer braucht (panary-cloud ADR 0028).

Ohne diesen Hinweis wäre die **Edge-Hälfte des Modells strukturell ungeschützt**: Wer hier den Sync-Pfad oder das Pairing ändert, hätte keinen Anlass gehabt, das Modell anzufassen — die Pflegeregel stünde nur im Nachbar-Repo. Das ist der schwächste Punkt der Ablageort-Entscheidung, und dieser PR mildert ihn.

## Auslöser in diesem Repo

- neuer Deployable oder Hintergrund-Worker mit Außenwirkung
- geänderter Sync-Pfad (Endpunkte, Allowlists, Transport) oder Pairing-Flow
- neuer öffentlich erreichbarer Endpunkt am Edge → `#public`
- echter TSE-Adapter statt Simulator → `#planned` / `#partial` fällt weg
- neue externe Integration (Drucker-Protokoll, Provider, Discovery)

**Nicht** modellrelevant: Schema-Felder, Lint-/Style-Regeln, reines Refactoring, Migrationen ohne Strukturwirkung. Ein ADR allein ist ausdrücklich **kein** Auslöser.

Der Modell-Commit landet in `panary-cloud`, nicht hier.

## Hinweise

- Reine Regel-Änderung, kein Code. Keine Auswirkung auf Build oder Tests.
- Verweist auf **panary-cloud#25** — idealerweise nach diesem mergen, sonst zeigt der ADR-0028-Link kurzzeitig ins Leere (laut Doku-Regeln zulässig, aber unschön).
- Die Regel leistet Disziplin, keine Mechanik: `arch:validate` im Cloud-Repo prüft nur, ob das Modell parst — nicht, ob es noch stimmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)