### PR TITLE
fix(infra): Registry-Vorabprüfung im Edge-Installer

### DIFF
--- a/docs/infrastructure/edge-installation-ghcr-pull.md
+++ b/docs/infrastructure/edge-installation-ghcr-pull.md
@@ -1,0 +1,84 @@
+---
+type: Guide
+title: Edge-Installation — GHCR-Pull-Fehler „denied: denied"
+description: Der Installer bricht mit „denied: denied" ab, obwohl das Edge-Image öffentlich ist — Ursache sind abgelaufene lokale ghcr.io-Credentials, erkannt durch die Registry-Vorabprüfung in install.sh.
+tags: [api-edge, docker, infra, deployment]
+status: stable
+generated: { by: claude-code/opus-5, at: 2026-07-27T16:08:22Z }
+sources:
+  - { id: install-sh, resource: tools/hosting/get.panary.io/install.sh, title: Edge-Installationsskript }
+  - { id: build-workflow, resource: .github/workflows/build-edge-docker.yml, title: Build Edge Docker (GHCR-Push) }
+---
+
+# Edge-Installation: GHCR-Pull-Fehler „denied: denied"
+
+## Symptom
+
+Beim Aufsetzen eines weiteren Edge-Servers scheitert der Installer am Image-Pull:
+
+```
+→ Image pullen: ghcr.io/panary/panary-edge:latest
+ ✘ Image ghcr.io/panary/panary-edge:latest  Error Head "https://ghcr.io/v2/panary/panary-edge/manifests/latest": denied: denied
+```
+
+Erstmals beobachtet am 2026-07-27 bei einer Zweitinstallation (Host `cpc-buero`).
+
+## Ursache
+
+**Nicht** die Paket-Sichtbarkeit. Das Paket `ghcr.io/panary/panary-edge` ist öffentlich —
+ein anonymer Manifest-Request beantwortet GHCR mit `HTTP 200`, ohne jede Credential:
+
+```bash
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:panary/panary-edge:pull&service=ghcr.io" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+curl -s -o /dev/null -w '%{http_code}\n' -I -H "Authorization: Bearer $TOKEN" \
+  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  https://ghcr.io/v2/panary/panary-edge/manifests/latest
+```
+
+Die Ursache liegt im Client: Sobald in der Docker-Config (`~/.docker/config.json`) ein
+Eintrag für `ghcr.io` steht — typischerweise ein abgelaufener PAT oder ein defekter
+Credential-Helper — schickt Docker diesen Token mit. GHCR antwortet dann mit `denied`,
+**statt** auf den anonymen Pfad zurückzufallen. Ohne jede Credential läuft derselbe Pull
+durch.
+
+Fallstrick bei der Suche nach der richtigen Config-Datei: `install.sh` pullt per
+`su "$REAL_USER"`, also mit dem Home des aufrufenden Users — **nicht** mit dem von root,
+obwohl das Skript unter `sudo` läuft. Beide Pfade prüfen.
+
+## Behebung
+
+```bash
+docker logout ghcr.io        # als der User, dem der Installer gehört
+sudo docker logout ghcr.io   # zusätzlich als root
+```
+
+Danach `install.sh` erneut ausführen — das Skript ist idempotent und behält die bestehende
+`.env` samt `FEATHERS_SECRET`.
+
+## Registry-Vorabprüfung im Installer
+
+`tools/hosting/get.panary.io/install.sh` prüft seit 2026-07-27 vor jedem Schreibzugriff die
+Registry — bewusst per `curl` **an der Docker-Config vorbei**, damit die Frage „Paket/Netz
+oder lokaler Login?" schon vor dem Pull beantwortet ist:
+
+| HTTP | Bedeutung | Verhalten |
+|---|---|---|
+| `200` | Image öffentlich erreichbar | Weiter; zusätzlich Warnung, falls ein ghcr.io-Login existiert |
+| `404` | Tag existiert nicht (z. B. Tippfehler in `--tag`) | Abbruch mit Link auf die Tag-Liste |
+| `401`/`403` ohne Login | Paket nicht öffentlich | Abbruch mit `docker login`-Anleitung |
+| `401`/`403` mit Login | Zugriff läuft über den vorhandenen Login | Warnung, weiter |
+| `000` | Registry nicht erreichbar (Proxy/DNS/Firewall) | Warnung, weiter |
+
+Zusätzlich meldet der Installer gefundene `ghcr.io`-Einträge in den Docker-Configs von
+aufrufendem User und root. Schlägt der Pull trotz `HTTP 200` fehl, gibt der Fehlerpfad
+direkt die `docker logout`-Kommandos und die betroffenen Config-Dateien aus.
+
+## Kein GitHub-Token nötig
+
+Das Image wird von [`build-edge-docker.yml`](../../.github/workflows/build-edge-docker.yml)
+bei jedem `v*`-Tag nach `ghcr.io/<owner>/panary-edge` gepusht und ist öffentlich lesbar. Für
+die Installation braucht es **keinen** Personal Access Token. Ein `docker login ghcr.io` ist
+nur nötig, falls die Paket-Sichtbarkeit künftig auf privat gestellt wird — dann meldet die
+Vorabprüfung `401`/`403` und bricht mit der passenden Anleitung ab.
+
+Siehe auch: [Docker-Build-Fix — Native Module](docker-native-module-fix.md).

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -3,6 +3,7 @@
 CI, Docker, Deployment und Infra-Betrieb (`type: Guide` oder `Architecture`).
 
 * [Docker-Build-Fix — Native Module für Cross-Platform-Deployment](docker-native-module-fix.md) - Docker-Build von api-edge nutzt durchgängig glibc-basierte bookworm-slim-Stages, damit native Module wie sqlite3 plattformübergreifend lauffähig sind.
+* [Edge-Installation — GHCR-Pull-Fehler „denied: denied"](edge-installation-ghcr-pull.md) - Der Installer bricht mit „denied: denied" ab, obwohl das Edge-Image öffentlich ist — Ursache sind abgelaufene lokale ghcr.io-Credentials, erkannt durch die Registry-Vorabprüfung in install.sh.
 * [Nx Self-Hosted Remote Cache — Server, Sicherheit & Setup](nx-remote-cache.md) - Geteilter Nx-Remote-Cache für core und cloud auf eigener Coolify/MinIO-Infra mit OpenAPI-Cache-Server und CI-seitigem Token-Scoping gegen Cache-Poisoning.
 * [Self-hosted GitHub Actions Runner — Setup, Sicherheit & Betrieb](self-hosted-runner.md) - Setup, Sicherheit und Betrieb des geteilten Org-Level self-hosted GitHub-Actions-Runners für core und cloud auf dem Staging-Host als systemd-Dienst.
 * [TypeScript-7-Migration — Status, Blocker & Vorbereitung](typescript-7-migration.md) - Status der TypeScript-7-Migration (GA 2026-07-08) mit den aktuellen Blockern durch die fehlende TS-API, der umgesetzten tsconfig-Vorbereitung und den Triggern für den Re-Check.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-27
 
+* **Creation**: [Edge-Installation — GHCR-Pull-Fehler „denied: denied"](infrastructure/edge-installation-ghcr-pull.md) — Pull-Abbruch bei Zweitinstallation trotz öffentlichem Paket; Ursache sind abgelaufene lokale ghcr.io-Credentials (GHCR fällt dann nicht auf anonym zurück), Behebung per `docker logout ghcr.io`, plus Registry-Vorabprüfung in `install.sh` mit HTTP-Status-Matrix.
 * **Creation**: [ADR 0013 — Fluide POS-UI-Skalierung](adr/0013-pos-fluide-ui-skalierung.md) — Root-rem-Skalierung (clamp × Terminal-Density) hinter dem Klassen-Gate `pnry-fluid-scale`; px→rem-Äquivalenz hält den Flag-off-Pfad pixelidentisch, Terminal-Flag lokal per localStorage, Device-Self-Patch-Absicherung für `uiScale`.
 * **Creation**: [Fluide POS-UI-Skalierung & Terminal-Density — Mechanik-Referenz](architecture/pos-fluid-ui-scaling.md) — CSS-Tokens, Tailwind-Variant `fluid:`, Touch-Floors, `UiScaleService`-Persistenz, px-Audit-Gate und Rollout-Schritte.
 

--- a/tools/hosting/get.panary.io/install.sh
+++ b/tools/hosting/get.panary.io/install.sh
@@ -74,6 +74,95 @@ if ! docker compose version &> /dev/null; then
 fi
 echo -e "${GREEN}✓${NC} Docker Compose gefunden: $(docker compose version --short)"
 
+# --- Registry-Vorabpruefung ---------------------------------------------------
+# Hintergrund (2026-07-27, Zweitinstallation cpc-buero): Der Pull scheiterte mit
+#   denied: denied
+# obwohl das GHCR-Paket oeffentlich ist. Ursache ist NICHT die Sichtbarkeit,
+# sondern der Client: sobald in der Docker-Config ein (abgelaufener) Login fuer
+# ghcr.io liegt, schickt Docker diesen Token mit — und GHCR antwortet dann mit
+# `denied`, statt auf den anonymen Pfad zurueckzufallen. Ohne jede Credential
+# laeuft derselbe Pull durch.
+#
+# Die Probe geht bewusst an der Docker-Config VORBEI (reines curl gegen die
+# Registry-API) und beantwortet damit genau die Frage, die im Fehlerfall zaehlt:
+# liegt es am Paket/Netz — oder am lokalen Login?
+REPO="${IMAGE#ghcr.io/}"
+REGISTRY_CODE="skipped"
+GHCR_CRED_FILES=""
+
+# Docker-Config des Users, der spaeter tatsaechlich pullt (siehe `su` weiter
+# unten), plus root — je nachdem wie das Skript aufgerufen wurde, greift die eine
+# oder die andere.
+find_ghcr_logins() {
+  local user home cfg
+  for user in "${SUDO_USER:-$(whoami)}" root; do
+    # Fehlschlag hier ist harmlos (unbekannter User, kein getent) — darf aber
+    # unter `set -e` nicht den ganzen Installer abbrechen.
+    home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6)" || home=""
+    [ -n "$home" ] || continue
+    cfg="${home}/.docker/config.json"
+    [ -f "$cfg" ] || continue
+    case " ${GHCR_CRED_FILES} " in *" ${cfg} "*) continue ;; esac
+    if grep -q '"ghcr\.io"' "$cfg" 2>/dev/null; then
+      GHCR_CRED_FILES="${GHCR_CRED_FILES}${cfg} "
+    fi
+  done
+}
+
+# Gibt den HTTP-Status des Manifest-Requests zurueck ("000" = keine Verbindung).
+probe_registry() {
+  local token code
+  token="$(curl -fsS --max-time 10 \
+    "https://ghcr.io/token?scope=repository:${REPO}:pull&service=ghcr.io" 2>/dev/null \
+    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')" || { echo "000"; return 0; }
+  [ -n "$token" ] || { echo "000"; return 0; }
+  code="$(curl -sS -I -o /dev/null -w '%{http_code}' --max-time 10 \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/${REPO}/manifests/${TAG}" 2>/dev/null)" || code="000"
+  echo "${code:-000}"
+}
+
+find_ghcr_logins
+
+if ! command -v curl &> /dev/null; then
+  echo -e "${YELLOW}⚠${NC} curl nicht gefunden — Registry-Vorabpruefung uebersprungen."
+else
+  REGISTRY_CODE="$(probe_registry)"
+  case "$REGISTRY_CODE" in
+    200)
+      echo -e "${GREEN}✓${NC} Image oeffentlich erreichbar: ${IMAGE}:${TAG} (kein GitHub-Token noetig)"
+      ;;
+    404)
+      echo -e "${RED}Image-Tag existiert nicht: ${IMAGE}:${TAG}${NC}"
+      echo "Verfuegbare Tags: https://github.com/panary/panary-core/pkgs/container/panary-edge"
+      exit 1
+      ;;
+    401|403)
+      if [ -n "$GHCR_CRED_FILES" ]; then
+        echo -e "${YELLOW}⚠${NC} Anonymer Zugriff auf ${IMAGE}:${TAG} verweigert (HTTP ${REGISTRY_CODE})."
+        echo -e "  Es existiert ein ghcr.io-Login — der Pull laeuft darueber. Weiter."
+      else
+        echo -e "${RED}Kein anonymer Zugriff auf ${IMAGE}:${TAG} (HTTP ${REGISTRY_CODE}).${NC}"
+        echo "Das Paket ist derzeit nicht oeffentlich. Vor der Installation anmelden:"
+        echo "  echo <GITHUB_TOKEN> | docker login ghcr.io -u <github-user> --password-stdin"
+        exit 1
+      fi
+      ;;
+    *)
+      echo -e "${YELLOW}⚠${NC} Registry nicht erreichbar (HTTP ${REGISTRY_CODE}) — Proxy/DNS/Firewall?"
+      echo -e "  Installation laeuft weiter; der Pull kann scheitern."
+      ;;
+  esac
+fi
+
+if [ -n "$GHCR_CRED_FILES" ] && [ "$REGISTRY_CODE" = "200" ]; then
+  echo -e "${YELLOW}⚠${NC} Gespeicherter ghcr.io-Login gefunden:"
+  for cfg in $GHCR_CRED_FILES; do echo "    ${cfg}"; done
+  echo -e "  Das Image ist oeffentlich — der Login wird nicht gebraucht und fuehrt,"
+  echo -e "  falls abgelaufen, zu \"denied: denied\". Im Fehlerfall: ${BOLD}docker logout ghcr.io${NC}"
+fi
+
 # Port pruefen
 if command -v ss &> /dev/null; then
   if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then
@@ -228,7 +317,32 @@ fi
 # ============================================================
 echo -e "${BLUE}→ Image pullen: ${IMAGE}:${TAG}${NC}"
 cd "$INSTALL_DIR"
-su "$REAL_USER" -c "cd ${INSTALL_DIR} && docker compose pull"
+if ! su "$REAL_USER" -c "cd ${INSTALL_DIR} && docker compose pull"; then
+  echo ""
+  echo -e "${RED}Image-Pull fehlgeschlagen.${NC}"
+  if [ "$REGISTRY_CODE" = "200" ]; then
+    # Die Vorabpruefung hat das Manifest anonym gelesen — Paket und Netzwerkweg
+    # sind also in Ordnung. Bleibt der lokale Docker-Client als Ursache.
+    echo -e "Die Registry liefert ${IMAGE}:${TAG} anonym aus (HTTP 200) — Paket und"
+    echo -e "Netzwerk sind in Ordnung. Ursache ist der lokale Docker-Client:"
+    echo ""
+    echo -e "  ${BOLD}docker logout ghcr.io${NC}          # als ${REAL_USER}"
+    echo -e "  ${BOLD}sudo docker logout ghcr.io${NC}     # zusaetzlich als root"
+    echo ""
+    if [ -n "$GHCR_CRED_FILES" ]; then
+      echo -e "Betroffene Config-Dateien:"
+      for cfg in $GHCR_CRED_FILES; do echo "    ${cfg}"; done
+      echo ""
+    fi
+    echo -e "Danach dieses Skript einfach erneut ausfuehren (es ist idempotent)."
+  else
+    echo -e "Registry-Vorabpruefung: HTTP ${REGISTRY_CODE}. Pruefen:"
+    echo -e "  • Internetzugang / Proxy / Firewall auf ghcr.io"
+    echo -e "  • /etc/docker/daemon.json (Registry-Mirror, Proxy-Eintraege)"
+    echo -e "  • docker logout ghcr.io (abgelaufene Credentials)"
+  fi
+  exit 1
+fi
 
 echo -e "${BLUE}→ Container starten...${NC}"
 su "$REAL_USER" -c "cd ${INSTALL_DIR} && docker compose up -d"


### PR DESCRIPTION
## Problem

Eine Zweitinstallation des Edge-Servers (Host `cpc-buero`, 2026-07-27) brach beim Image-Pull ab:

```
✘ Image ghcr.io/panary/panary-edge:latest  Error Head ".../manifests/latest": denied: denied
```

Ursache ist **nicht** die Paket-Sichtbarkeit — `ghcr.io/panary/panary-edge` ist öffentlich, ein anonymer Manifest-Request liefert `HTTP 200`. Es ist der Client: liegt in der Docker-Config ein abgelaufener `ghcr.io`-Login, schickt Docker den toten Token mit, und GHCR fällt daraufhin **nicht** auf den anonymen Pfad zurück, sondern antwortet `denied`.

Fallstrick bei der Fehlersuche: `install.sh` pullt per `su "$REAL_USER"`, also mit dem Home des aufrufenden Users — nicht mit dem von root, obwohl alles unter `sudo` läuft.

## Änderung

`install.sh` prüft die Registry jetzt **vor jedem Schreibzugriff** per `curl`, bewusst an der Docker-Config vorbei, und beantwortet damit vorab die entscheidende Frage „Paket/Netz oder lokaler Login?":

| HTTP | Bedeutung | Verhalten |
|---|---|---|
| `200` | Image öffentlich erreichbar | weiter (+ Warnung, falls ein ghcr.io-Login existiert) |
| `404` | Tag existiert nicht (Tippfehler in `--tag`) | Abbruch mit Link auf die Tag-Liste |
| `401`/`403` ohne Login | Paket nicht öffentlich | Abbruch mit `docker login`-Anleitung |
| `401`/`403` mit Login | Zugriff läuft über den Login | Warnung, weiter |
| `000` | Registry nicht erreichbar | Warnung (Proxy/DNS/Firewall), weiter |

Zusätzlich:
- gefundene `ghcr.io`-Einträge in den Docker-Configs von aufrufendem User **und** root werden mit Pfad gemeldet
- schlägt `docker compose pull` trotz `HTTP 200` fehl, gibt der Fehlerpfad direkt die `docker logout`-Kommandos und die betroffenen Config-Dateien aus
- der `getent`-Aufruf ist gegen `set -e` abgesichert (fehlender User bzw. fehlendes `getent` liefert Exit ≠ 0 und hätte den Installer sonst hart abgebrochen)

Keine Verhaltensänderung im Erfolgsfall — nur eine zusätzliche Zeile Ausgabe.

## Verifikation

- `bash -n` sauber
- gegen die echte Registry: `latest` und `26.7.26` → `200`; Fantasie-Tag `99.9.9` → `404` + Abbruch
- mit gestubbtem `curl`/`getent` alle Zweige durchgespielt: Login gefunden + `200` → Warnung; `403` mit Login → weiter; `403` ohne Login → Abbruch; `000` → Warnung; Pull-Fehler bei `200` → korrekte Logout-Anleitung

## Doku

`docs/infrastructure/edge-installation-ghcr-pull.md` (Symptom → Ursache → Behebung → Status-Matrix), Ordner-Index und `docs/log.md` im selben Commit gepflegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)