### PR TITLE
fix(admin-client): WebSocket-Verbindung ueber LAN-IP — Origin statt localhost

### DIFF
--- a/apps/admin-client/src/app/app.config.ts
+++ b/apps/admin-client/src/app/app.config.ts
@@ -9,6 +9,32 @@ import { appRoutes } from './app.routes'
 import { authInterceptor } from './core/auth.interceptor'
 import packageJson from '../../../../package.json'
 
+// Fallback fuer den Angular-Dev-Server (Port 4202): dort laeuft das Panel unter
+// `baseHref: '/'` und das Edge-Backend liegt auf einem anderen Port.
+const DEV_SERVER_API_URL = 'http://localhost:3030'
+
+/**
+ * Basis-URL des Edge-Backends.
+ *
+ * Im Production-Build liefert das Edge-Backend das Panel selbst unter `/admin/`
+ * aus (`baseHref`, siehe `apps/api-edge/src/app.ts`) — Panel und API teilen sich
+ * also immer denselben Origin, egal ob `localhost`, LAN-IP oder Hostname.
+ *
+ * Ohne diese Ableitung stand hier fix `http://localhost:3030`: beim Aufruf ueber
+ * die LAN-IP (z.B. `http://10.10.100.3:3030/admin`) zeigte der WebSocket damit auf
+ * den *Client*-Rechner statt auf den Server → Dauerfehler "Keine Verbindung zum
+ * Server". Der `/assets/config.json`-Laufzeit-Override (`AppConfigService`) greift
+ * hier nicht: er wird beim Bootstrap nie aufgerufen und laege wegen des `baseHref`
+ * ohnehin unter einem anderen Pfad.
+ */
+function resolveApiUrl(): string {
+  // `baseURI` spiegelt das gebaute `<base href>` — `/admin/` nur im Production-Build,
+  // die Routen selbst tragen kein `/admin`-Praefix.
+  return document.baseURI.includes('/admin/') ? window.location.origin : DEV_SERVER_API_URL
+}
+
+const apiUrl = resolveApiUrl()
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
@@ -20,16 +46,16 @@ export const appConfig: ApplicationConfig = {
     // APP_CONFIG-Provider — Pflicht, weil `AppConfigService` (von
     // `ConnectionService` injiziert) `inject(APP_CONFIG)` aufruft.
     // Ohne diesen Provider: NG0201 beim App-Bootstrap, weisse Seite. Werte
-    // analog `apps/pos-client/src/app/app.config.ts`; Production-Override
-    // erfolgt zur Laufzeit ueber `/assets/config.json` (siehe `AppConfigService.loadConfig`).
+    // analog `apps/pos-client/src/app/app.config.ts`; `apiUrl` wird zur Laufzeit
+    // aus dem Origin abgeleitet (siehe `resolveApiUrl`).
     {
       provide: APP_CONFIG,
       useValue: {
-        apiUrl: 'http://localhost:3030',
+        apiUrl,
         websocketPath: '/ws',
         production: false,
         appVersion: packageJson.version,
-        basicServerUrl: 'http://localhost:3030',
+        basicServerUrl: apiUrl,
         printOut: false,
         localStorageServerSettingsKey: 'panary_server_settings',
         localStorageLastLoggedInUserKey: 'panary_last_user',

--- a/apps/api-edge/src/app.ts
+++ b/apps/api-edge/src/app.ts
@@ -216,12 +216,53 @@ app.use(async (ctx, next) => {
 // request-code authentifiziert sich manuell (siehe device-pairing.ts).
 registerDevicePairingRoutes(app)
 
+/**
+ * CORS-Regel fuer den Socket-Transport: statische Allowlist aus der Config
+ * (`origins`) PLUS Same-Origin.
+ *
+ * Das Admin-Panel wird vom Edge selbst unter `/admin` ausgeliefert und laeuft
+ * damit zwangslaeufig unter dem Host, ueber den der Server gerade angesprochen
+ * wird — `localhost`, LAN-IP oder Hostname im Kundennetz. Eine statische Liste
+ * kann diese Hosts nicht kennen. Sicherheitsneutral: Same-Origin ist genau der
+ * Fall, den die Same-Origin-Policy ohnehin erlaubt; CORS schuetzt gegen
+ * *cross*-origin-Zugriffe, und die bleiben auf die Allowlist beschraenkt.
+ *
+ * Ohne diese Ausnahme liefert der Polling-Handshake ueber die LAN-IP kein
+ * `Access-Control-Allow-Origin` → der Browser verwirft die Antwort. Der
+ * WebSocket-Transport kommt durch (fuer WS erzwingen Browser keine
+ * CORS-Header), der Polling-Rueckfallweg im Client waere aber wirkungslos.
+ *
+ * Das `cors`-Paket (via engine.io) akzeptiert an dieser Stelle einen Delegate
+ * `(req, cb)` — nur so kommt man an den `Host`-Header und damit an die
+ * Same-Origin-Entscheidung; `cors.origin(origin, cb)` bekommt den Request nicht.
+ */
+const socketCorsDelegate = (
+  req: { headers: Record<string, string | string[] | undefined> },
+  callback: (err: Error | null, options: { origin: string | false }) => void
+) => {
+  const allowlist: string[] = app.get('origins') ?? []
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined
+  const host = typeof req.headers.host === 'string' ? req.headers.host : undefined
+
+  let isSameOrigin = false
+  if (origin && host) {
+    try {
+      isSameOrigin = new URL(origin).host === host
+    } catch {
+      isSameOrigin = false
+    }
+  }
+
+  const allowed = !!origin && (isSameOrigin || allowlist.includes(origin))
+  callback(null, { origin: allowed ? origin : false })
+}
+
 // Transports
 app.configure(rest())
 app.configure(
   socketio(
     {
-      cors: { origin: app.get('origins') },
+      cors: socketCorsDelegate as never,
       path: '/ws',
       serveClient: false,
       pingInterval: 10000,

--- a/libs/shared/data-access/src/lib/services/connection.service.ts
+++ b/libs/shared/data-access/src/lib/services/connection.service.ts
@@ -665,7 +665,11 @@ export class ConnectionService {
 
       options = {
         path: '/ws',
-        transports: ['websocket'],
+        // WebSocket zuerst, Polling als Rueckfallweg — analog zum Device-Zweig.
+        // Ohne `polling` gibt es keinen Ausweg, sobald ein Reverse-Proxy den
+        // Upgrade-Header nicht weiterreicht: der Client bleibt dann dauerhaft in
+        // der Reconnect-Schleife statt auf HTTP-Long-Polling zurueckzufallen.
+        transports: ['websocket', 'polling'],
         timeout: 10000,
         reconnection: true,
         reconnectionAttempts: Infinity,


### PR DESCRIPTION
## Problem

Das Admin-Panel verband sich fix mit `http://localhost:3030`. Beim Aufruf über die LAN-IP (z.B. `http://10.10.100.3:3030/admin`) zeigte der WebSocket damit auf den **Client**-Rechner statt auf den Server — Dauerbanner „Keine Verbindung zum Server" bei einwandfrei laufendem Edge, plus Anzeige-Fallback auf „Standalone-Modus", weil `#fetchHealth()` dieselbe URL nutzt.

Der im Code versprochene `/assets/config.json`-Laufzeit-Override konnte nie greifen: `AppConfigService.loadConfig()` wird beim Bootstrap nicht aufgerufen, die Datei existiert in keinem Build, und sie läge wegen `baseHref: '/admin/'` ohnehin unter einem anderen Pfad.

## Änderungen

1. **`apps/admin-client/src/app/app.config.ts`** — `apiUrl`/`basicServerUrl` werden aus `window.location.origin` abgeleitet. Das Panel wird vom Edge selbst unter `/admin/` ausgeliefert, teilt sich also immer den Origin mit der API. Der Angular-Dev-Server (baseHref `/`, Port 4202) behält den localhost-Fallback.

2. **`libs/shared/data-access/.../connection.service.ts`** — Admin-Zweig erlaubt `polling` als Rückfallweg (analog Device-Zweig). Ohne ihn gibt es keinen Ausweg, wenn ein Reverse-Proxy den Upgrade-Header nicht weiterreicht.

3. **`apps/api-edge/src/app.ts`** — Socket-CORS erlaubt zusätzlich Same-Origin. Notwendig, damit (2) überhaupt wirkt: Die `origins`-Allowlist kennt nur localhost und ist weder per ENV noch in `production.json` überschreibbar, der Polling-Handshake über die LAN-IP bekam deshalb kein `Access-Control-Allow-Origin`. Cross-Origin bleibt unverändert auf die Allowlist begrenzt.

## Verifikation

Am laufenden Edge geprüft (Polling-Handshake `/ws/?EIO=4&transport=polling`):

| Fall | Ergebnis |
|---|---|
| Same-Origin LAN-IP | ACAO gesetzt (vorher: fehlte) |
| fremde Seite cross-origin | kein ACAO (unverändert) |
| `tauri.localhost` (POS) | ACAO gesetzt (unverändert) |
| `localhost:4202` (Dev) | ACAO gesetzt (unverändert) |

Panel im Browser unter `/admin/` geladen: `document.baseURI = http://localhost:3030/admin/`, Socket verbindet (`Socket "…" established connection`). `nx test api-edge`: 233/233 grün. `nx build admin-client` + `nx build api-edge` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)