### PR TITLE
fix(businessdays): Kassen-Freigabe-Dialog konsolidieren — kein Sackgassen-Zustand bei falscher PIN

### DIFF
--- a/apps/api-edge/src/services/cash-sessions/cash-sessions.ts
+++ b/apps/api-edge/src/services/cash-sessions/cash-sessions.ts
@@ -3,7 +3,7 @@ import { hooks as schemaHooks } from '@feathersjs/schema'
 import { BadRequest, Forbidden } from '@feathersjs/errors'
 import { authorize, ensureIndexes, getJsonFieldHooks, logger, multiTenancy } from '@panary/shared-backend'
 import { createServiceAdapter } from '@panary/shared/data-access/server'
-import { DatabaseType } from '@panary/shared-common'
+import { AppError, AppErrorMessages, DatabaseType } from '@panary/shared-common'
 import {
   cashSessionDataSchema,
   cashSessionPatchSchema,
@@ -56,10 +56,9 @@ const requireAuthorizedCreate = async (context: HookContext): Promise<HookContex
   if (isFromSync(context)) return context
   const role = (context.params.user as { role?: string } | undefined)?.role
   if (role && PRIVILEGED_CASH_SESSION_ROLES.has(role)) return context
-  throw new Forbidden(
-    'Die Kassen-Eröffnung muss von einem berechtigten Mitarbeiter (Manager/Inhaber) autorisiert werden.',
-    { code: 'CASH_SESSION_AUTH_REQUIRED' },
-  )
+  throw new Forbidden(AppErrorMessages[AppError.CASH_SESSION_AUTH_REQUIRED], {
+    code: AppError.CASH_SESSION_AUTH_REQUIRED,
+  })
 }
 
 /**
@@ -122,7 +121,9 @@ export const cashSessions = (app: Application) => {
         authorizedByUserId,
         businessDayId,
       })
-      throw new Forbidden('PIN ungültig.', { code: 'CASH_SESSION_AUTH_REQUIRED' })
+      throw new Forbidden(AppErrorMessages[AppError.CASH_SESSION_PIN_INVALID], {
+        code: AppError.CASH_SESSION_PIN_INVALID,
+      })
     }
 
     // 2. Rollencheck: nur privilegierte Mitarbeiter dürfen autorisieren.
@@ -134,8 +135,8 @@ export const cashSessions = (app: Application) => {
         authorizedByUserId,
         businessDayId,
       })
-      throw new Forbidden('Dieser Mitarbeiter darf keine Kasse freigeben.', {
-        code: 'CASH_SESSION_AUTH_REQUIRED',
+      throw new Forbidden(AppErrorMessages[AppError.CASH_SESSION_ROLE_DENIED], {
+        code: AppError.CASH_SESSION_ROLE_DENIED,
       })
     }
 

--- a/apps/pos-client/src/assets/i18n/de.json
+++ b/apps/pos-client/src/assets/i18n/de.json
@@ -417,6 +417,26 @@
     "TITLE": "Geschäftstag eröffnen",
     "SUBMIT": "Eröffnen"
   },
+  "CASH_SESSION": {
+    "AUTH_TITLE": "Kasse freigeben",
+    "AUTH_CASHIER_FALLBACK": "den Kassierer",
+    "AUTH_INTRO": "Für {{name}} ist noch keine Kasse eröffnet. Ein berechtigter Mitarbeiter muss die Eröffnung freigeben.",
+    "AUTH_LOADING_USERS": "Berechtigte Mitarbeiter werden geladen...",
+    "AUTH_OPENING_FLOAT": "Wechselgeld-Anfangsbestand",
+    "AUTH_OPENING_FLOAT_INVALID": "Bitte einen gültigen Betrag ab 0 € eingeben.",
+    "AUTH_SELECT_MANAGER": "Freigebende Person wählen",
+    "AUTH_NO_ELIGIBLE_USERS": "Kein berechtigter Mitarbeiter verfügbar.",
+    "AUTH_NO_PIN_USERS": "Kein berechtigter Mitarbeiter hat einen POS-PIN hinterlegt.",
+    "AUTH_ENTER_PIN": "PIN eingeben, um die Kasse freizugeben",
+    "AUTH_AMOUNT_LABEL": "Wechselgeld",
+    "AUTH_ERROR_PIN_INVALID": "PIN ungültig. Bitte erneut versuchen.",
+    "AUTH_ERROR_ROLE_DENIED": "Dieser Mitarbeiter darf keine Kasse freigeben.",
+    "AUTH_ERROR_GENERIC": "Freigabe fehlgeschlagen. Bitte erneut versuchen.",
+    "AUTH_LOAD_ERROR": "Mitarbeiterliste konnte nicht geladen werden.",
+    "AUTH_IN_PROGRESS": "Kasse wird freigegeben...",
+    "AUTH_SUCCESS": "Kasse eröffnet",
+    "AUTH_SUCCESS_DETAIL": "{{name}} · Wechselgeld {{amount}}"
+  },
   "SETUP": {
     "TITLE": "Setup",
     "CONNECT_TITLE": "Mit Panary verbinden",

--- a/apps/pos-client/src/assets/i18n/de.json
+++ b/apps/pos-client/src/assets/i18n/de.json
@@ -431,6 +431,7 @@
     "AUTH_AMOUNT_LABEL": "Wechselgeld",
     "AUTH_ERROR_PIN_INVALID": "PIN ungültig. Bitte erneut versuchen.",
     "AUTH_ERROR_ROLE_DENIED": "Dieser Mitarbeiter darf keine Kasse freigeben.",
+    "AUTH_ERROR_NOT_AUTHORIZED": "Die Kassen-Eröffnung muss von einem berechtigten Mitarbeiter freigegeben werden.",
     "AUTH_ERROR_GENERIC": "Freigabe fehlgeschlagen. Bitte erneut versuchen.",
     "AUTH_LOAD_ERROR": "Mitarbeiterliste konnte nicht geladen werden.",
     "AUTH_IN_PROGRESS": "Kasse wird freigegeben...",

--- a/apps/pos-client/src/assets/i18n/en.json
+++ b/apps/pos-client/src/assets/i18n/en.json
@@ -417,6 +417,26 @@
     "TITLE": "Open business day",
     "SUBMIT": "Open"
   },
+  "CASH_SESSION": {
+    "AUTH_TITLE": "Authorize cash drawer",
+    "AUTH_CASHIER_FALLBACK": "the cashier",
+    "AUTH_INTRO": "No cash drawer has been opened for {{name}} yet. An authorized staff member has to approve it.",
+    "AUTH_LOADING_USERS": "Loading authorized staff...",
+    "AUTH_OPENING_FLOAT": "Opening float",
+    "AUTH_OPENING_FLOAT_INVALID": "Please enter a valid amount of 0 € or more.",
+    "AUTH_SELECT_MANAGER": "Select approving person",
+    "AUTH_NO_ELIGIBLE_USERS": "No authorized staff member available.",
+    "AUTH_NO_PIN_USERS": "No authorized staff member has a POS PIN set up.",
+    "AUTH_ENTER_PIN": "Enter PIN to authorize the cash drawer",
+    "AUTH_AMOUNT_LABEL": "Float",
+    "AUTH_ERROR_PIN_INVALID": "Invalid PIN. Please try again.",
+    "AUTH_ERROR_ROLE_DENIED": "This staff member may not authorize a cash drawer.",
+    "AUTH_ERROR_GENERIC": "Authorization failed. Please try again.",
+    "AUTH_LOAD_ERROR": "Staff list could not be loaded.",
+    "AUTH_IN_PROGRESS": "Authorizing cash drawer...",
+    "AUTH_SUCCESS": "Cash drawer opened",
+    "AUTH_SUCCESS_DETAIL": "{{name}} · float {{amount}}"
+  },
   "SETUP": {
     "TITLE": "Setup",
     "CONNECT_TITLE": "Connect to Panary",

--- a/apps/pos-client/src/assets/i18n/en.json
+++ b/apps/pos-client/src/assets/i18n/en.json
@@ -431,6 +431,7 @@
     "AUTH_AMOUNT_LABEL": "Float",
     "AUTH_ERROR_PIN_INVALID": "Invalid PIN. Please try again.",
     "AUTH_ERROR_ROLE_DENIED": "This staff member may not authorize a cash drawer.",
+    "AUTH_ERROR_NOT_AUTHORIZED": "Opening a cash drawer must be authorized by an eligible staff member.",
     "AUTH_ERROR_GENERIC": "Authorization failed. Please try again.",
     "AUTH_LOAD_ERROR": "Staff list could not be loaded.",
     "AUTH_IN_PROGRESS": "Authorizing cash drawer...",

--- a/apps/pos-client/src/assets/i18n/tr.json
+++ b/apps/pos-client/src/assets/i18n/tr.json
@@ -431,6 +431,7 @@
     "AUTH_AMOUNT_LABEL": "Bozuk para",
     "AUTH_ERROR_PIN_INVALID": "PIN geçersiz. Lütfen tekrar deneyin.",
     "AUTH_ERROR_ROLE_DENIED": "Bu çalışan kasa onayı veremez.",
+    "AUTH_ERROR_NOT_AUTHORIZED": "Kasa açılışı yetkili bir çalışan tarafından onaylanmalıdır.",
     "AUTH_ERROR_GENERIC": "Onay başarısız. Lütfen tekrar deneyin.",
     "AUTH_LOAD_ERROR": "Çalışan listesi yüklenemedi.",
     "AUTH_IN_PROGRESS": "Kasa onaylanıyor...",

--- a/apps/pos-client/src/assets/i18n/tr.json
+++ b/apps/pos-client/src/assets/i18n/tr.json
@@ -417,6 +417,26 @@
     "TITLE": "İşletme gününü aç",
     "SUBMIT": "Aç"
   },
+  "CASH_SESSION": {
+    "AUTH_TITLE": "Kasayı onayla",
+    "AUTH_CASHIER_FALLBACK": "kasiyer",
+    "AUTH_INTRO": "{{name}} için henüz bir kasa açılmadı. Yetkili bir çalışanın açılışı onaylaması gerekir.",
+    "AUTH_LOADING_USERS": "Yetkili çalışanlar yükleniyor...",
+    "AUTH_OPENING_FLOAT": "Başlangıç bozuk para tutarı",
+    "AUTH_OPENING_FLOAT_INVALID": "Lütfen 0 € veya üzeri geçerli bir tutar girin.",
+    "AUTH_SELECT_MANAGER": "Onaylayan kişiyi seçin",
+    "AUTH_NO_ELIGIBLE_USERS": "Yetkili çalışan bulunamadı.",
+    "AUTH_NO_PIN_USERS": "Hiçbir yetkili çalışanın POS PIN'i tanımlı değil.",
+    "AUTH_ENTER_PIN": "Kasayı onaylamak için PIN girin",
+    "AUTH_AMOUNT_LABEL": "Bozuk para",
+    "AUTH_ERROR_PIN_INVALID": "PIN geçersiz. Lütfen tekrar deneyin.",
+    "AUTH_ERROR_ROLE_DENIED": "Bu çalışan kasa onayı veremez.",
+    "AUTH_ERROR_GENERIC": "Onay başarısız. Lütfen tekrar deneyin.",
+    "AUTH_LOAD_ERROR": "Çalışan listesi yüklenemedi.",
+    "AUTH_IN_PROGRESS": "Kasa onaylanıyor...",
+    "AUTH_SUCCESS": "Kasa açıldı",
+    "AUTH_SUCCESS_DETAIL": "{{name}} · bozuk para {{amount}}"
+  },
   "SETUP": {
     "TITLE": "Kurulum",
     "CONNECT_TITLE": "Panary'ye bağlan",

--- a/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.html
+++ b/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.html
@@ -1,0 +1,294 @@
+<!-- Kein eigener Radius auf dem Root — die panelClass `rounded-dialog` setzt
+     border-radius + overflow:hidden auf der Material-Surface. -->
+<div class="flex flex-col max-h-[85vh] bg-white dark:bg-gray-950">
+  <!-- Header -->
+  <div class="flex items-center justify-between p-5 border-b border-gray-100 dark:border-gray-800">
+    <div class="flex items-center gap-3">
+      <div
+        class="h-10 w-10 rounded-full bg-blue-50 dark:bg-blue-950 flex items-center justify-center text-blue-600 dark:text-blue-400"
+      >
+        <span class="material-symbols-outlined text-[1.25rem]">point_of_sale</span>
+      </div>
+      <div>
+        <h2 class="text-base font-bold text-gray-800 dark:text-white">
+          {{ 'CASH_SESSION.AUTH_TITLE' | translate }}
+        </h2>
+        <p class="text-xs text-gray-500 dark:text-gray-400">{{ cashierLabel() }}</p>
+      </div>
+    </div>
+    <button
+      type="button"
+      (click)="cancel()"
+      [disabled]="step() === 'submitting'"
+      class="flex items-center justify-center w-9 h-9 rounded-lg text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+      [attr.aria-label]="'COMMON.CLOSE' | translate"
+    >
+      <span class="material-symbols-outlined text-[1.25rem]">close</span>
+    </button>
+  </div>
+
+  <!-- Content -->
+  <div class="flex-1 overflow-y-auto p-5">
+    @switch (step()) {
+      @case ('loading') {
+        <div class="flex flex-col items-center justify-center py-12 gap-3">
+          <span class="material-symbols-outlined text-[2.5rem] text-gray-400 dark:text-gray-500 animate-spin">
+            sync
+          </span>
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            {{ 'CASH_SESSION.AUTH_LOADING_USERS' | translate }}
+          </p>
+        </div>
+      }
+
+      @case ('input') {
+        <div class="flex flex-col gap-4">
+          <p class="text-sm text-gray-600 dark:text-gray-300">
+            {{ 'CASH_SESSION.AUTH_INTRO' | translate: { name: cashierLabel() } }}
+          </p>
+
+          <!-- Wechselgeld -->
+          <label class="flex flex-col gap-1.5">
+            <span class="text-xs font-medium text-gray-500 dark:text-gray-400">
+              {{ 'CASH_SESSION.AUTH_OPENING_FLOAT' | translate }}
+            </span>
+            <span class="relative flex items-center">
+              <input
+                type="number"
+                inputmode="decimal"
+                min="0"
+                step="0.01"
+                autocomplete="off"
+                [value]="openingFloatEuros() ?? ''"
+                (input)="onOpeningFloatInput($event)"
+                class="w-full h-14 pl-4 pr-10 rounded-xl border bg-white dark:bg-gray-900 text-right text-lg font-semibold text-gray-800 dark:text-white"
+                [class.border-gray-300]="canContinue()"
+                [class.dark:border-gray-700]="canContinue()"
+                [class.border-red-400]="!canContinue()"
+              />
+              <span class="absolute right-4 text-gray-400 dark:text-gray-500 font-semibold pointer-events-none">€</span>
+            </span>
+            @if (!canContinue()) {
+              <span class="text-xs text-red-600 dark:text-red-400">
+                {{ 'CASH_SESSION.AUTH_OPENING_FLOAT_INVALID' | translate }}
+              </span>
+            }
+          </label>
+
+          <!-- Freigebende Person -->
+          <div class="flex flex-col gap-2">
+            <span class="text-xs font-medium text-gray-500 dark:text-gray-400">
+              {{ 'CASH_SESSION.AUTH_SELECT_MANAGER' | translate }}
+            </span>
+
+            @if (hasManagers()) {
+              @for (manager of managers(); track manager._id) {
+                <button
+                  type="button"
+                  (click)="selectManager(manager)"
+                  [disabled]="!canContinue()"
+                  class="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-800 transition-colors text-left disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  <div
+                    class="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 font-bold flex items-center justify-center"
+                  >
+                    {{ manager.initials || '??' }}
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <p class="font-semibold text-gray-800 dark:text-white truncate">{{ manager.fullName }}</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                      {{ manager.staffRole || manager.role }}
+                    </p>
+                  </div>
+                  <span class="material-symbols-outlined text-gray-300 dark:text-gray-600 text-[1.25rem]">
+                    chevron_right
+                  </span>
+                </button>
+              }
+            } @else {
+              <div class="flex flex-col items-center text-center gap-3 py-8">
+                <span class="material-symbols-outlined text-[2.5rem] text-gray-300 dark:text-gray-600">person_off</span>
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                  @if (managersWithoutPin() > 0) {
+                    {{ 'CASH_SESSION.AUTH_NO_PIN_USERS' | translate }}
+                  } @else {
+                    {{ 'CASH_SESSION.AUTH_NO_ELIGIBLE_USERS' | translate }}
+                  }
+                </p>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      @case ('enter-pin') {
+        @if (selectedManager(); as manager) {
+          <div class="flex flex-col items-center gap-5">
+            <div class="flex flex-col items-center gap-2">
+              <div
+                class="h-14 w-14 rounded-full bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 font-bold text-xl flex items-center justify-center"
+              >
+                {{ manager.initials || '??' }}
+              </div>
+              <p class="font-semibold text-gray-800 dark:text-white">{{ manager.fullName }}</p>
+              <p class="text-xs text-gray-500 dark:text-gray-400">{{ manager.staffRole || manager.role }}</p>
+            </div>
+
+            <p class="text-sm text-gray-600 dark:text-gray-300 text-center">
+              {{ 'CASH_SESSION.AUTH_ENTER_PIN' | translate }}
+            </p>
+
+            <!-- Betrags-Kontext: was hier gleich freigegeben wird -->
+            <div
+              class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs text-gray-600 dark:text-gray-300"
+            >
+              <span class="material-symbols-outlined text-[0.875rem]">payments</span>
+              {{ 'CASH_SESSION.AUTH_AMOUNT_LABEL' | translate }} {{ openingFloatLabel() }}
+            </div>
+
+            <!-- PIN-Anzeige -->
+            <div class="flex gap-3" [class.pin-shake]="pinError()">
+              @for (i of pinSlots; track i) {
+                <div
+                  class="w-3.5 h-3.5 rounded-full transition-colors"
+                  [class.bg-blue-500]="pin().length > i && !pinError()"
+                  [class.bg-red-500]="pinError()"
+                  [class.bg-gray-200]="pin().length <= i && !pinError()"
+                  [class.dark:bg-gray-700]="pin().length <= i && !pinError()"
+                ></div>
+              }
+            </div>
+
+            @if (errorMessage()) {
+              <p class="text-xs text-red-600 dark:text-red-400 text-center">{{ errorMessage() }}</p>
+            }
+
+            <!-- PIN-Pad -->
+            <div class="grid grid-cols-3 gap-2 w-full max-w-[16.25rem]">
+              @for (digit of digits; track digit) {
+                <button
+                  type="button"
+                  (click)="addDigit(digit)"
+                  class="h-14 rounded-xl bg-gray-100 dark:bg-gray-800 text-xl font-semibold text-gray-800 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-95 transition-all"
+                >
+                  {{ digit }}
+                </button>
+              }
+              <button
+                type="button"
+                (click)="backToInput()"
+                class="h-14 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-95 transition-all flex items-center justify-center"
+                [attr.aria-label]="'COMMON.BACK' | translate"
+              >
+                <span class="material-symbols-outlined text-[1.25rem]">person</span>
+              </button>
+              <button
+                type="button"
+                (click)="addDigit('0')"
+                class="h-14 rounded-xl bg-gray-100 dark:bg-gray-800 text-xl font-semibold text-gray-800 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-95 transition-all"
+              >
+                0
+              </button>
+              <button
+                type="button"
+                (click)="deleteDigit()"
+                class="h-14 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-95 transition-all flex items-center justify-center"
+                [attr.aria-label]="'COMMON.DELETE' | translate"
+              >
+                <span class="material-symbols-outlined text-[1.25rem]">backspace</span>
+              </button>
+            </div>
+          </div>
+        }
+      }
+
+      @case ('submitting') {
+        <div class="flex flex-col items-center justify-center py-12 gap-3">
+          <span class="material-symbols-outlined text-[2.5rem] text-blue-500 animate-spin">sync</span>
+          <p class="text-sm text-gray-500 dark:text-gray-400">{{ 'CASH_SESSION.AUTH_IN_PROGRESS' | translate }}</p>
+        </div>
+      }
+
+      @case ('submitted') {
+        <div class="flex flex-col items-center text-center justify-center py-10 gap-3">
+          <span class="material-symbols-outlined text-[2.5rem] text-emerald-500">check_circle</span>
+          <p class="text-sm font-semibold text-gray-800 dark:text-white">
+            {{ 'CASH_SESSION.AUTH_SUCCESS' | translate }}
+          </p>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            {{
+              'CASH_SESSION.AUTH_SUCCESS_DETAIL' | translate: { name: cashierLabel(), amount: openingFloatLabel() }
+            }}
+          </p>
+        </div>
+      }
+
+      @case ('load-error') {
+        <div class="flex flex-col items-center text-center gap-3 py-6">
+          <span class="material-symbols-outlined text-[2.5rem] text-red-500">error</span>
+          <p class="text-sm font-semibold text-gray-800 dark:text-white">
+            {{ 'CASH_SESSION.AUTH_LOAD_ERROR' | translate }}
+          </p>
+          @if (errorMessage()) {
+            <p class="text-xs text-gray-500 dark:text-gray-400 break-words max-w-full">{{ errorMessage() }}</p>
+          }
+        </div>
+      }
+    }
+  </div>
+
+  <!-- Footer / Actions -->
+  @switch (step()) {
+    @case ('input') {
+      <div class="flex gap-2 p-4 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          (click)="cancel()"
+          class="flex-1 h-12 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-semibold hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+        >
+          {{ 'COMMON.CANCEL' | translate }}
+        </button>
+      </div>
+    }
+    @case ('enter-pin') {
+      <div class="flex gap-2 p-4 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          (click)="cancel()"
+          class="flex-1 h-12 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-semibold hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+        >
+          {{ 'COMMON.CANCEL' | translate }}
+        </button>
+      </div>
+    }
+    @case ('submitted') {
+      <div class="flex gap-2 p-4 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          (click)="close()"
+          class="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold transition-colors"
+        >
+          {{ 'COMMON.CLOSE' | translate }}
+        </button>
+      </div>
+    }
+    @case ('load-error') {
+      <div class="flex gap-2 p-4 border-t border-gray-100 dark:border-gray-800">
+        <button
+          type="button"
+          (click)="cancel()"
+          class="flex-1 h-12 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-semibold hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+        >
+          {{ 'COMMON.CLOSE' | translate }}
+        </button>
+        <button
+          type="button"
+          (click)="retryLoad()"
+          class="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold transition-colors"
+        >
+          {{ 'COMMON.RETRY' | translate }}
+        </button>
+      </div>
+    }
+  }
+</div>

--- a/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.scss
+++ b/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.scss
@@ -1,0 +1,26 @@
+/* Shake-Feedback bei falscher PIN — komponenten-scoped, weil es global keine
+   .animate-shake-Regel gibt (dieselbe Lösung wie in login.component.scss).
+   Eigene Klasse statt Tailwind-Arbitrary-Value, weil `[class.animate-[…]]`
+   im Angular-Template nicht parsebar ist. */
+.pin-shake {
+  animation: shake 0.3s ease-out;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-0.5rem);
+  }
+  40% {
+    transform: translateX(0.5rem);
+  }
+  60% {
+    transform: translateX(-0.25rem);
+  }
+  80% {
+    transform: translateX(0.25rem);
+  }
+}

--- a/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.ts
+++ b/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.ts
@@ -1,12 +1,12 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core'
-import { FormsModule } from '@angular/forms'
-import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog'
-import { TranslateModule } from '@ngx-translate/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
 
 import { CashSession } from '@panary/businessdays/domain'
 import { CashSessionService } from '@panary/businessdays/data-access'
-import { User, UserSystemRole } from '@panary/users/domain'
-import { UserService } from '@panary/users/data-access'
+import { ConnectionService } from '@panary/shared/data-access'
+import { User, UserStatus, UserSystemRole } from '@panary/users/domain'
 
 export interface ManagerAuthorizeCashSessionDialogData {
   businessDayId: string
@@ -17,173 +17,328 @@ export interface ManagerAuthorizeCashSessionDialogData {
   defaultOpeningFloatCents?: number
 }
 
-type DialogPhase = 'input' | 'submitting' | 'submitted' | 'failed'
+type DialogStep = 'loading' | 'input' | 'enter-pin' | 'submitting' | 'submitted' | 'load-error'
+
+interface AuthorizingManager {
+  _id: string
+  fullName: string
+  initials: string
+  staffRole?: string
+  role: string
+}
 
 /** Rollen, die eine Kassen-Eröffnung autorisieren dürfen (Spiegel von PRIVILEGED_CASH_SESSION_ROLES). */
-const AUTHORIZING_ROLES = new Set<string>([
+const AUTHORIZING_ROLES: readonly string[] = [
   UserSystemRole.PLATFORM_OWNER,
   UserSystemRole.PLATFORM_ADMIN,
   UserSystemRole.PLATFORM_SUPPORT,
   UserSystemRole.TENANT_OWNER,
   UserSystemRole.TENANT_MANAGER,
   UserSystemRole.TENANT_TECHNICIAN,
-])
+]
+
+/** POS-PINs sind über alle POS-Oberflächen hinweg vierstellig (vgl. Login, Storno, Unpair). */
+const PIN_LENGTH = 4
+
+/** Anzeigedauer des Erfolgs-Screens, bevor der Dialog sich selbst schließt. */
+const AUTO_CLOSE_MS = 1200
+
+/**
+ * Fehlercodes des Edge-Backends → i18n-Key. Aktuell wirft `openAuthorized` für
+ * „PIN falsch" und „Rolle unzulässig" denselben Code `CASH_SESSION_AUTH_REQUIRED`;
+ * sobald distinkte Codes existieren, greift diese Map ohne weitere Änderung.
+ */
+const AUTH_ERROR_KEYS: Record<string, string> = {
+  BD_6005: 'CASH_SESSION.AUTH_ERROR_PIN_INVALID',
+  BD_6006: 'CASH_SESSION.AUTH_ERROR_ROLE_DENIED',
+}
 
 /**
  * POS-Dialog: Eine Kasse muss durch einen berechtigten Mitarbeiter
- * (Schichtleiter/Manager/Inhaber) freigegeben werden. Dieser wählt sich aus,
- * gibt seinen POS-PIN ein und hinterlegt das Wechselgeld (vorausgefüllt aus dem
- * Standort-Default). Die Kasse wird auf den KASSIERER eröffnet (openedBy), nicht
- * auf den autorisierenden Manager. Der PIN wird server-seitig geprüft
- * (cash-sessions.openAuthorized → users.verifyPin).
+ * (Schichtleiter/Manager/Inhaber) freigegeben werden. Schritt 1 erfasst das
+ * Wechselgeld und die freigebende Person, Schritt 2 deren POS-PIN. Die Kasse
+ * wird auf den KASSIERER eröffnet (openedBy), nicht auf den autorisierenden
+ * Manager. Der PIN wird server-seitig geprüft (cash-sessions.openAuthorized →
+ * users.verifyPin).
+ *
+ * Ein Fehlversuch führt bewusst NICHT in einen eigenen Schritt zurück, sondern
+ * bleibt in `enter-pin` — Managerauswahl und Betrag bleiben erhalten, damit nur
+ * der PIN korrigiert werden muss.
  */
 @Component({
   selector: 'app-manager-authorize-cash-session-dialog',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatDialogModule, TranslateModule, FormsModule],
-  template: `
-    <h2 mat-dialog-title>Kasse freigeben</h2>
-    <mat-dialog-content class="text-sm space-y-3">
-      @if (phase() === 'input') {
-        <p class="text-gray-600 dark:text-gray-300">
-          Für
-          <span class="font-medium">{{ data.cashierName || 'den Kassierer' }}</span>
-          ist noch keine Kasse eröffnet. Ein berechtigter Mitarbeiter muss die Eröffnung freigeben.
-        </p>
-
-        <label class="flex flex-col gap-1">
-          <span class="text-xs text-gray-500 dark:text-gray-400">Freigebende Person</span>
-          <select
-            [ngModel]="managerId()"
-            (ngModelChange)="managerId.set($event)"
-            class="border border-gray-300 dark:border-gray-700 rounded-xl px-3 py-2 bg-white dark:bg-gray-900 h-12"
-          >
-            <option value="">— bitte wählen —</option>
-            @for (m of managers(); track m._id) {
-              <option [value]="m._id">{{ m.firstName }} {{ m.lastName }}</option>
-            }
-          </select>
-        </label>
-
-        <label class="flex flex-col gap-1">
-          <span class="text-xs text-gray-500 dark:text-gray-400">PIN</span>
-          <input
-            type="password"
-            inputmode="numeric"
-            autocomplete="off"
-            [ngModel]="pin()"
-            (ngModelChange)="pin.set($event)"
-            class="border border-gray-300 dark:border-gray-700 rounded-xl px-3 py-2 bg-white dark:bg-gray-900 h-12"
-          />
-        </label>
-
-        <label class="flex flex-col gap-1">
-          <span class="text-xs text-gray-500 dark:text-gray-400">Wechselgeld-Anfangsbestand (€)</span>
-          <input
-            type="number"
-            step="0.01"
-            min="0"
-            [ngModel]="openingFloatEuros()"
-            (ngModelChange)="openingFloatEuros.set($event)"
-            class="border border-gray-300 dark:border-gray-700 rounded-xl px-3 py-2 bg-white dark:bg-gray-900 h-12"
-          />
-        </label>
-      } @else if (phase() === 'submitting') {
-        <p>Kasse wird freigegeben…</p>
-      } @else if (phase() === 'submitted') {
-        <p>Kasse eröffnet — die Bestellung kann jetzt kassiert werden.</p>
-      } @else {
-        <div class="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded-xl">
-          {{ errorMessage() }}
-        </div>
-      }
-    </mat-dialog-content>
-    <mat-dialog-actions class="flex justify-end gap-2">
-      @if (phase() === 'submitted') {
-        <button class="bg-white dark:bg-gray-800 border rounded-xl px-4 h-12" (click)="close()">
-          {{ 'COMMON.CLOSE' | translate }}
-        </button>
-      } @else {
-        <button
-          class="bg-white dark:bg-gray-800 border rounded-xl px-4 h-12"
-          (click)="cancel()"
-          [disabled]="phase() === 'submitting'"
-        >
-          {{ 'COMMON.CANCEL' | translate }}
-        </button>
-        <button
-          class="bg-blue-600 text-white rounded-xl px-4 h-12 disabled:opacity-50"
-          [disabled]="!canSubmit() || phase() === 'submitting'"
-          (click)="submit()"
-        >
-          Freigeben
-        </button>
-      }
-    </mat-dialog-actions>
-  `,
+  imports: [TranslateModule],
+  templateUrl: './manager-authorize-cash-session-dialog.component.html',
+  styleUrl: './manager-authorize-cash-session-dialog.component.scss',
 })
 export class ManagerAuthorizeCashSessionDialogComponent {
-  private dialogRef = inject(MatDialogRef<ManagerAuthorizeCashSessionDialogComponent>)
-  private cashSessionService = inject(CashSessionService)
-  private userService = inject(UserService)
+  readonly #dialogRef = inject(MatDialogRef<ManagerAuthorizeCashSessionDialogComponent, CashSession | null>)
+  readonly #cashSessionService = inject(CashSessionService)
+  readonly #connectionService = inject(ConnectionService)
+  readonly #translate = inject(TranslateService)
   protected readonly data = inject<ManagerAuthorizeCashSessionDialogData>(MAT_DIALOG_DATA)
 
-  protected readonly phase = signal<DialogPhase>('input')
+  protected readonly step = signal<DialogStep>('loading')
+  protected readonly managers = signal<AuthorizingManager[]>([])
+  /** Berechtigte Mitarbeiter ohne POS-PIN — steuert die aussagekräftigere Leer-Meldung. */
+  protected readonly managersWithoutPin = signal(0)
+  protected readonly selectedManager = signal<AuthorizingManager | null>(null)
+  protected readonly pin = signal('')
+  protected readonly pinError = signal(false)
   protected readonly errorMessage = signal<string | null>(null)
-  protected resultSession: CashSession | null = null
 
-  // Formular-State als Signals, damit `canSubmit` (computed) auf Änderungen
-  // reagiert. Plain Properties + [(ngModel)] mutieren nur die Property, aber
-  // triggern kein Signal-Re-Compute → der Submit-Button bliebe dauerhaft
-  // deaktiviert.
-  protected readonly managerId = signal<string>('')
-  protected readonly pin = signal<string>('')
+  // Vorbelegung aus dem Standort-Default; ohne Default 0, damit die
+  // Manager-Auswahl sofort tippbar ist („kein Wechselgeld" ist ein gültiger Wert).
   protected readonly openingFloatEuros = signal<number | null>(
     typeof this.data.defaultOpeningFloatCents === 'number' && this.data.defaultOpeningFloatCents > 0
       ? this.data.defaultOpeningFloatCents / 100
-      : null,
+      : 0,
   )
 
-  /** Berechtigte Mitarbeiter zur Auswahl. */
-  protected readonly managers = computed<User[]>(() =>
-    this.userService.users().filter(u => !!u.role && AUTHORIZING_ROLES.has(u.role)),
-  )
+  protected readonly digits = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
+  protected readonly pinSlots = Array.from({ length: PIN_LENGTH }, (_, i) => i)
 
-  protected readonly canSubmit = computed(() => {
-    const float = this.openingFloatEuros()
-    return (
-      this.managerId().trim().length > 0 &&
-      this.pin().trim().length > 0 &&
-      float !== null &&
-      float >= 0
-    )
+  protected readonly hasManagers = computed(() => this.managers().length > 0)
+
+  protected readonly canContinue = computed(() => {
+    const euros = this.openingFloatEuros()
+    return euros !== null && Number.isFinite(euros) && euros >= 0
   })
 
-  async submit(): Promise<void> {
-    this.phase.set('submitting')
+  protected readonly openingFloatCents = computed(() => Math.round((this.openingFloatEuros() ?? 0) * 100))
+
+  protected readonly openingFloatLabel = computed(() =>
+    (this.openingFloatCents() / 100).toLocaleString('de-DE', {
+      style: 'currency',
+      currency: 'EUR',
+      minimumFractionDigits: 2,
+    }),
+  )
+
+  protected readonly cashierLabel = computed(
+    () => this.data.cashierName?.trim() || this.#translate.instant('CASH_SESSION.AUTH_CASHIER_FALLBACK'),
+  )
+
+  #resultSession: CashSession | null = null
+  #autoCloseTimer: ReturnType<typeof setTimeout> | null = null
+  #closed = false
+
+  constructor() {
+    // Backdrop-Fehltipp oder ESC dürfen mitten in der PIN-Eingabe nicht den
+    // laufenden Kassiervorgang abbrechen — Schließen läuft nur über cancel()/close().
+    this.#dialogRef.disableClose = true
+
+    // Kein window:keydown — der CDK-OverlayKeyboardDispatcher routet Keydowns
+    // an das oberste Overlay; ein globaler Listener würde zusätzlich fremde
+    // Overlays mitlesen und ESC doppelt behandeln.
+    this.#dialogRef
+      .keydownEvents()
+      .pipe(takeUntilDestroyed())
+      .subscribe(event => this.#onKeydown(event))
+
+    inject(DestroyRef).onDestroy(() => this.#clearAutoClose())
+
+    void this.#loadManagers()
+  }
+
+  protected onOpeningFloatInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).valueAsNumber
+    this.openingFloatEuros.set(Number.isNaN(value) ? null : value)
+  }
+
+  protected selectManager(manager: AuthorizingManager): void {
+    if (!this.canContinue()) return
+    this.selectedManager.set(manager)
+    this.pin.set('')
+    this.pinError.set(false)
     this.errorMessage.set(null)
-    try {
-      this.resultSession = await this.cashSessionService.openAuthorized({
-        businessDayId: this.data.businessDayId,
-        openedBy: this.data.cashierId,
-        openingFloatCents: Math.round((this.openingFloatEuros() ?? 0) * 100),
-        label: this.data.cashierName ? `Kasse ${this.data.cashierName}` : 'Kasse',
-        authorizedByUserId: this.managerId(),
-        pin: this.pin(),
-      })
-      this.phase.set('submitted')
-    } catch (err) {
-      this.phase.set('failed')
-      this.errorMessage.set((err as Error).message ?? 'Freigabe fehlgeschlagen')
+    this.step.set('enter-pin')
+  }
+
+  protected backToInput(): void {
+    this.selectedManager.set(null)
+    this.pin.set('')
+    this.pinError.set(false)
+    this.errorMessage.set(null)
+    this.step.set('input')
+  }
+
+  protected addDigit(digit: string): void {
+    if (this.step() !== 'enter-pin' || this.pin().length >= PIN_LENGTH) return
+    this.pin.update(current => current + digit)
+    this.pinError.set(false)
+    this.errorMessage.set(null)
+    if (this.pin().length === PIN_LENGTH) {
+      // Kurz verzögert, damit der vierte Punkt vor dem Request sichtbar wird (wie im Login).
+      setTimeout(() => void this.submit(), 100)
     }
   }
 
-  cancel(): void {
-    this.dialogRef.close(null)
+  protected deleteDigit(): void {
+    this.pin.update(current => current.slice(0, -1))
+    this.pinError.set(false)
+    this.errorMessage.set(null)
   }
 
-  close(): void {
-    this.dialogRef.close(this.resultSession)
+  protected async submit(): Promise<void> {
+    const manager = this.selectedManager()
+    if (!manager || this.step() !== 'enter-pin' || this.pin().length < PIN_LENGTH) return
+
+    const pin = this.pin()
+    this.step.set('submitting')
+    this.errorMessage.set(null)
+
+    try {
+      this.#resultSession = await this.#cashSessionService.openAuthorized({
+        businessDayId: this.data.businessDayId,
+        openedBy: this.data.cashierId,
+        openingFloatCents: this.openingFloatCents(),
+        label: this.data.cashierName ? `Kasse ${this.data.cashierName}` : 'Kasse',
+        authorizedByUserId: manager._id,
+        pin,
+      })
+      this.pin.set('')
+      this.step.set('submitted')
+      this.#autoCloseTimer = setTimeout(() => this.close(), AUTO_CLOSE_MS)
+    } catch (err) {
+      // Zurück in die PIN-Eingabe statt in einen Fehler-Schritt: Manager und
+      // Betrag bleiben erhalten, nur der PIN muss korrigiert werden.
+      this.errorMessage.set(this.#toErrorMessage(err))
+      this.pin.set('')
+      this.pinError.set(true)
+      this.step.set('enter-pin')
+      navigator.vibrate?.([100, 50, 100])
+    }
   }
+
+  protected retryLoad(): void {
+    void this.#loadManagers()
+  }
+
+  protected cancel(): void {
+    if (this.step() === 'submitting') return
+    this.#close(null)
+  }
+
+  protected close(): void {
+    this.#close(this.#resultSession)
+  }
+
+  async #loadManagers(): Promise<void> {
+    this.step.set('loading')
+    this.errorMessage.set(null)
+
+    try {
+      // Bewusst der rohe Feathers-Service statt UserService: letzterer läuft
+      // durch handleError und würde zusätzlich zum Inline-Fehlerschritt eine
+      // Notification werfen. Zudem ist die Rollen-Query hier explizit, statt
+      // sich auf den paginierten Auto-Load der User-Liste zu verlassen.
+      const response = await this.#connectionService.usersService.find({
+        query: {
+          role: { $in: [...AUTHORIZING_ROLES] },
+          $sort: { firstName: 1 },
+          $limit: 100,
+        },
+      })
+      const eligible = (Array.isArray(response) ? response : (response?.data ?? [])) as User[]
+
+      // `hasPosPin` ist ein virtuelles Feld des externen Resolvers und daher
+      // nicht query-fähig — es spiegelt exakt die Server-Bedingung von verifyPin.
+      // Kein isPosUser-Filter: das Backend prüft nur PIN und Rolle, ein
+      // Manager ohne POS-Kennzeichnung dürfte also freigeben.
+      const active = eligible.filter(user => user.status === UserStatus.ACTIVE)
+      const withPin = active.filter(user => user.hasPosPin === true)
+
+      this.managersWithoutPin.set(active.length - withPin.length)
+      this.managers.set(withPin.map(user => this.#toManager(user)))
+      this.step.set('input')
+    } catch (err) {
+      this.errorMessage.set(err instanceof Error ? err.message : String(err))
+      this.step.set('load-error')
+    }
+  }
+
+  #toManager(user: User): AuthorizingManager {
+    const firstName = user.firstName ?? ''
+    const lastName = user.lastName ?? ''
+    return {
+      _id: String(user._id),
+      fullName: `${firstName} ${lastName}`.trim(),
+      initials: `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase(),
+      staffRole: user.staffRole,
+      role: user.role,
+    }
+  }
+
+  #onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      this.cancel()
+      return
+    }
+    // Der Dispatcher liefert auch Tastendrücke aus dem Wechselgeld-Feld —
+    // ohne diese Sperre landeten sie im PIN.
+    if (this.step() !== 'enter-pin') return
+
+    if (event.key === 'Backspace' || event.key === 'Delete') {
+      event.preventDefault()
+      this.deleteDigit()
+      return
+    }
+    if (/^[0-9]$/.test(event.key)) {
+      event.preventDefault()
+      this.addDigit(event.key)
+    }
+  }
+
+  #toErrorMessage(err: unknown): string {
+    const error = err as { message?: string; data?: { code?: string } } | undefined
+    const appCode = error?.data?.code
+
+    if (appCode && AUTH_ERROR_KEYS[appCode]) return this.#translate.instant(AUTH_ERROR_KEYS[appCode])
+    if (appCode === 'CASH_SESSION_AUTH_REQUIRED') {
+      return error?.message?.trim() || this.#translate.instant('CASH_SESSION.AUTH_ERROR_PIN_INVALID')
+    }
+    return error?.message?.trim() || this.#translate.instant('CASH_SESSION.AUTH_ERROR_GENERIC')
+  }
+
+  /** Idempotent — Auto-Close-Timer und Button-Tipp dürfen sich nicht überholen. */
+  #close(result: CashSession | null): void {
+    if (this.#closed) return
+    this.#closed = true
+    this.#clearAutoClose()
+    this.#dialogRef.close(result)
+  }
+
+  #clearAutoClose(): void {
+    if (this.#autoCloseTimer === null) return
+    clearTimeout(this.#autoCloseTimer)
+    this.#autoCloseTimer = null
+  }
+}
+
+/**
+ * Öffnet den Kassen-Freigabe-Dialog mit der für alle Aufrufer identischen
+ * Konfiguration. Liefert die eröffnete `CashSession` oder `null` bei Abbruch.
+ */
+export function openManagerAuthorizeCashSessionDialog(
+  dialog: MatDialog,
+  data: ManagerAuthorizeCashSessionDialogData,
+): MatDialogRef<ManagerAuthorizeCashSessionDialogComponent, CashSession | null> {
+  return dialog.open<
+    ManagerAuthorizeCashSessionDialogComponent,
+    ManagerAuthorizeCashSessionDialogData,
+    CashSession | null
+  >(ManagerAuthorizeCashSessionDialogComponent, {
+    width: '28.75rem',
+    maxWidth: '92vw',
+    maxHeight: '90vh',
+    panelClass: 'rounded-dialog',
+    // Ohne Override fokussiert Material das erste Element (Schließen-X bzw. das
+    // Betragsfeld) — auf dem Sunmi-Tablet spränge dabei die Bildschirmtastatur auf.
+    autoFocus: 'dialog',
+    data,
+  })
 }

--- a/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.ts
+++ b/libs/domains/businessdays/feature-pos-closing-dialog/src/lib/manager-authorize-cash-session-dialog.component.ts
@@ -5,6 +5,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core'
 
 import { CashSession } from '@panary/businessdays/domain'
 import { CashSessionService } from '@panary/businessdays/data-access'
+import { AppError } from '@panary/shared-common'
 import { ConnectionService } from '@panary/shared/data-access'
 import { User, UserStatus, UserSystemRole } from '@panary/users/domain'
 
@@ -44,13 +45,13 @@ const PIN_LENGTH = 4
 const AUTO_CLOSE_MS = 1200
 
 /**
- * Fehlercodes des Edge-Backends → i18n-Key. Aktuell wirft `openAuthorized` für
- * „PIN falsch" und „Rolle unzulässig" denselben Code `CASH_SESSION_AUTH_REQUIRED`;
- * sobald distinkte Codes existieren, greift diese Map ohne weitere Änderung.
+ * Fehlercodes des Edge-Backends → i18n-Key. Die Server-Messages sind hartkodiert
+ * deutsch; über den Code können wir sie lokalisiert ausgeben.
  */
 const AUTH_ERROR_KEYS: Record<string, string> = {
-  BD_6005: 'CASH_SESSION.AUTH_ERROR_PIN_INVALID',
-  BD_6006: 'CASH_SESSION.AUTH_ERROR_ROLE_DENIED',
+  [AppError.CASH_SESSION_PIN_INVALID]: 'CASH_SESSION.AUTH_ERROR_PIN_INVALID',
+  [AppError.CASH_SESSION_ROLE_DENIED]: 'CASH_SESSION.AUTH_ERROR_ROLE_DENIED',
+  [AppError.CASH_SESSION_AUTH_REQUIRED]: 'CASH_SESSION.AUTH_ERROR_NOT_AUTHORIZED',
 }
 
 /**
@@ -298,9 +299,8 @@ export class ManagerAuthorizeCashSessionDialogComponent {
     const appCode = error?.data?.code
 
     if (appCode && AUTH_ERROR_KEYS[appCode]) return this.#translate.instant(AUTH_ERROR_KEYS[appCode])
-    if (appCode === 'CASH_SESSION_AUTH_REQUIRED') {
-      return error?.message?.trim() || this.#translate.instant('CASH_SESSION.AUTH_ERROR_PIN_INVALID')
-    }
+    // Unbekannter Code oder gar keiner (Timeout, 401, Validierung) — die
+    // Server-Message ist besser als nichts, sonst der generische Text.
     return error?.message?.trim() || this.#translate.instant('CASH_SESSION.AUTH_ERROR_GENERIC')
   }
 

--- a/libs/domains/orders/feature-pos-active/src/lib/active-orders.component.ts
+++ b/libs/domains/orders/feature-pos-active/src/lib/active-orders.component.ts
@@ -15,7 +15,7 @@ import { MatSnackBar } from '@angular/material/snack-bar'
 import { uuidv7 } from 'uuidv7'
 import { OrderDialogComponent } from '@panary/orders/feature-pos-order-dialog'
 import {
-  ManagerAuthorizeCashSessionDialogComponent,
+  openManagerAuthorizeCashSessionDialog,
   type ManagerAuthorizeCashSessionDialogData,
 } from '@panary/businessdays/feature-pos-closing-dialog'
 import type { CashSession } from '@panary/businessdays/domain'
@@ -329,17 +329,7 @@ export class ActiveOrdersComponent {
       cashierName: cashierName || undefined,
       defaultOpeningFloatCents: loc?.settings?.cashSessionSettings?.defaultOpeningFloatCents,
     }
-    const result = await firstValueFrom(
-      this.#matDialog
-        .open(ManagerAuthorizeCashSessionDialogComponent, {
-          width: '28.75rem',
-          maxWidth: '92vw',
-          maxHeight: '90vh',
-          disableClose: false,
-          data,
-        })
-        .afterClosed(),
-    )
+    const result = await firstValueFrom(openManagerAuthorizeCashSessionDialog(this.#matDialog, data).afterClosed())
     return !!(result as CashSession | null)
   }
 

--- a/libs/domains/orders/feature-pos-dashboard/src/lib/dashboard.component.ts
+++ b/libs/domains/orders/feature-pos-dashboard/src/lib/dashboard.component.ts
@@ -30,8 +30,8 @@ import { OrderDialogComponent } from '@panary/orders/feature-pos-order-dialog'
 import {
   CashSessionDialogComponent,
   ClosingDialogComponent,
-  ManagerAuthorizeCashSessionDialogComponent,
   OpeningDialogComponent,
+  openManagerAuthorizeCashSessionDialog,
 } from '@panary/businessdays/feature-pos-closing-dialog'
 import { BusinessDayOperationMode } from '@panary/businessdays/domain'
 import { PosWriteOffDialogComponent } from '@panary/write-offs/feature-pos-dialog'
@@ -562,9 +562,11 @@ export class DashboardComponent implements OnInit {
       console.warn('manageCashSession: kein offener Geschäftstag — Aktion ignoriert')
       return
     }
-    const user = this.#authService.user() as
-      | { _id?: string; firstName?: string; lastName?: string }
-      | undefined
+    // currentUser() statt authService.user(): auf einem POS-Gerät ist der
+    // Auth-User der Geräte-User (API-Key), nicht der per PIN angemeldete
+    // Kassierer. Die Kasse muss aber auf den Kassierer laufen, sonst greift der
+    // cash-session-Guard beim Kassieren weiterhin.
+    const user = this.currentUser()
     const userId = user?._id
     if (!userId) {
       console.warn('manageCashSession: kein angemeldeter Benutzer — Aktion ignoriert')
@@ -591,19 +593,15 @@ export class DashboardComponent implements OnInit {
         return
       }
 
-      // Keine Kasse → manager-autorisierte Eröffnung.
+      // Keine Kasse → manager-autorisierte Eröffnung. Das Ergebnis bleibt hier
+      // ungenutzt: der Dialog quittiert den Erfolg selbst und am Dashboard hängt
+      // kein Zustand an der Kasse (anders als beim Kassieren in active-orders).
       const cashierName = [user?.firstName, user?.lastName].filter(Boolean).join(' ').trim() || undefined
-      this.#dialog.open(ManagerAuthorizeCashSessionDialogComponent, {
-        width: '28.75rem',
-        maxWidth: '92vw',
-        maxHeight: '90vh',
-        disableClose: false,
-        data: {
-          businessDayId,
-          cashierId: userId,
-          cashierName,
-          defaultOpeningFloatCents: loc?.settings?.cashSessionSettings?.defaultOpeningFloatCents,
-        },
+      openManagerAuthorizeCashSessionDialog(this.#dialog, {
+        businessDayId,
+        cashierId: String(userId),
+        cashierName,
+        defaultOpeningFloatCents: loc?.settings?.cashSessionSettings?.defaultOpeningFloatCents,
       })
     })()
   }

--- a/libs/shared/common/src/lib/errors/app-errors.ts
+++ b/libs/shared/common/src/lib/errors/app-errors.ts
@@ -25,6 +25,14 @@ export const AppError = {
   BUSINESS_DAY_TOO_OLD: 'BD_6002',
   BUSINESS_DAY_OPEN_TOO_LONG: 'BD_6003',
   CASH_SESSION_REQUIRED: 'BD_6004',
+  // Manager-autorisierte Kassen-Eröffnung (`cash-sessions.openAuthorized`).
+  // Getrennte Codes, damit der Client „PIN falsch" und „Rolle unzulässig"
+  // unterscheiden und lokalisieren kann — ein gemeinsamer Code zwingt ihn
+  // sonst dazu, die hartkodiert deutsche Server-Message anzuzeigen.
+  CASH_SESSION_PIN_INVALID: 'BD_6005',
+  CASH_SESSION_ROLE_DENIED: 'BD_6006',
+  // Direkter externer `create` ohne Autorisierung (Härtung des CRUD-Pfads).
+  CASH_SESSION_AUTH_REQUIRED: 'BD_6007',
 
   // --- VALIDATION (4000-4999) ---
   VALIDATION_FAILED: 'VAL_4000',
@@ -63,6 +71,10 @@ export const AppErrorMessages: Record<AppError, string> = {
     'Der Geschäftstag ist zu lange geöffnet und kann nicht automatisch wechseln, weil noch Bestellungen offen sind. Bitte offene Bestellungen abschließen und den Geschäftstag abschließen.',
   [AppError.CASH_SESSION_REQUIRED]:
     'Für Sie ist noch keine Kasse eröffnet. Bitte eröffnen Sie zuerst Ihre Kasse oder wenden Sie sich an den Manager.',
+  [AppError.CASH_SESSION_PIN_INVALID]: 'PIN ungültig.',
+  [AppError.CASH_SESSION_ROLE_DENIED]: 'Dieser Mitarbeiter darf keine Kasse freigeben.',
+  [AppError.CASH_SESSION_AUTH_REQUIRED]:
+    'Die Kassen-Eröffnung muss von einem berechtigten Mitarbeiter (Manager/Inhaber) autorisiert werden.',
 
   [AppError.VALIDATION_FAILED]: 'Validation failed.',
   [AppError.INVALID_INPUT]: 'Invalid input provided.',


### PR DESCRIPTION
## Problem

Wenn für den Kassierer noch keine Kasse offen ist, wirft der Edge-Guard `BD_6004` und der POS
öffnet den Manager-Freigabe-Dialog. Dieser hatte die Phasen `input | submitting | submitted | failed`,
wobei das Formular **nur** in `input` gerendert wurde. Bei falscher PIN sprang er auf `failed` —
Managerauswahl, PIN-Feld und Wechselgeld verschwanden, übrig blieben eine rote Fehlerbox und ein
weiterhin aktiver „Freigeben"-Button, der exakt dieselbe falsche PIN erneut abschickte.

Ein Rückweg zur Eingabe existierte nicht: Abbrechen und den kompletten Kassiervorgang neu starten
war die einzige Option.

## Lösung

`failed` entfällt ersatzlos — damit ist die Sackgasse strukturell unmöglich statt bloß repariert.
Der Dialog folgt jetzt dem Muster von Unpair-Device und Login (Touch-First für Sunmi):

- **Schritt 1** — Wechselgeld (vorbelegt aus `location.settings.cashSessionSettings`) + freigebende
  Person als antippbare Avatar-Karten
- **Schritt 2** — PIN über Numpad mit 4 Dots, Auto-Submit bei der vierten Ziffer
- **Fehlversuch** bleibt in Schritt 2: nur die PIN wird geleert, die Meldung erscheint inline,
  Managerauswahl und Betrag bleiben erhalten

### Weitere Korrekturen im selben Zug

- **Manager-Liste** über einen expliziten `find()` statt des paginierten Auto-Loads, gefiltert auf
  das virtuelle Feld `hasPosPin` + `status=ACTIVE`. Bisher konnte man jemanden ohne POS-PIN wählen —
  garantierter Fehlschlag. Bewusst **kein** `isPosUser`-Filter: das Backend prüft in
  `cash-sessions.openAuthorized` nur PIN und Rolle, ein Manager ohne POS-Kennzeichnung darf also
  freigeben und würde sonst zu Unrecht fehlen.
- **`disableClose` + `keydownEvents()`** statt `window:keydown`. Ein Backdrop-Fehltipp bricht den
  laufenden Kassiervorgang nicht mehr ab, und Ziffern aus dem Betragsfeld landen nicht mehr im PIN
  (der CDK-`OverlayKeyboardDispatcher` reicht sie sonst durch).
- **Gemeinsamer Open-Helper** `openManagerAuthorizeCashSessionDialog()` statt duplizierter
  Dialog-Config in beiden Aufrufern.
- **i18n**: neuer Abschnitt `CASH_SESSION.AUTH_*` in de/en/tr — der Dialog war hart deutsch.
- **`dashboard.component.ts`**: `currentUser()` statt `authService.user()` als `cashierId`. Auf einem
  POS-Gerät ist der Auth-User der Geräte-User (API-Key), die Kasse lief damit auf den falschen
  `openedBy` — und der `restrict-order-to-cash-session`-Guard hätte den Kassierer weiterhin blockiert.

### Zweiter Commit: distinkte Fehlercodes

`openAuthorized` warf für „PIN falsch" und „Rolle unzulässig" denselben Inline-Code
`CASH_SESSION_AUTH_REQUIRED`. Der Client konnte beide Fälle nicht unterscheiden und musste die
hartkodiert deutsche Server-Message durchreichen — in en/tr unübersetzt. Jetzt in der zentralen
AppError-Registry:

| Code | Konstante | Bedeutung |
|---|---|---|
| `BD_6005` | `CASH_SESSION_PIN_INVALID` | PIN-Verifikation fehlgeschlagen |
| `BD_6006` | `CASH_SESSION_ROLE_DENIED` | Rolle darf keine Kasse freigeben |
| `BD_6007` | `CASH_SESSION_AUTH_REQUIRED` | direkter externer `create` ohne Autorisierung (andere Semantik, Härtung des CRUD-Pfads) |

Messages kommen aus `AppErrorMessages`, damit Code und Text eine Quelle haben; die Wortlaute sind
unverändert. Der Client mappt die Codes auf i18n-Keys statt auf Magic Strings. Rein additiv —
`BD_6004` und dessen Auswertung im `restrict-order`-Guard bleiben unberührt.

## Verifikation

`nx lint`, `nx build pos-client`, `nx build api-edge` und `pnpm audit:pos-px` sind grün.

Manuell am laufenden POS gegen ein frisch gestartetes `api-edge`, als `tenant:staff` angemeldet:

**Dialog-Flow**

- Schritt 1 zeigt Wechselgeld 200 € aus dem Standort-Default; die Manager-Liste enthält nur den
  berechtigten User mit POS-PIN (der archivierte Owner ohne PIN fällt korrekt raus)
- Falsche PIN → Dots werden rot, Meldung erscheint inline, PIN geleert — **Step bleibt `enter-pin`**,
  Manager und Betrag unverändert
- Backdrop-Klick schließt den Dialog nicht mehr; „Zurück" führt zu Schritt 1 mit erhaltenem Betrag
- Erfolgs-Screen, Light- und Dark-Mode geprüft, keine Konsolenfehler

**Fehlercodes**

- *PIN-Fall (`BD_6005`)*: angezeigt wird „PIN ungültig. **Bitte erneut versuchen.**" — das ist der
  i18n-Text, nicht die Server-Message („PIN ungültig." ohne Zusatz), die der Fallback geliefert
  hätte. Der String kann damit nur aus `AUTH_ERROR_KEYS[BD_6005]` stammen: Backend schickt den
  neuen Code, Client übersetzt ihn. Edge-Log: `cash_session.authorize_failed reason=pin` → `403`.
- *Rollen-Fall (`BD_6006`)*: PIN eines unberechtigten Users gegen dessen ID → bcrypt matcht
  serverseitig, danach greift der Rollencheck (`cash_session.authorize_failed reason=role`).
  Verhalten und Meldung sind korrekt; dass der Zweig speziell `BD_6006` trägt, ist **nur statisch**
  belegt — i18n-Text und Server-Message sind hier wortgleich, die Anzeige unterscheidet die Pfade
  also nicht. Der Zweig ist dieselbe Drei-Zeilen-Änderung wie der PIN-Zweig, dessen Mapping live
  funktioniert.
- Es wurde keine Kasse angelegt; in keiner Logzeile taucht ein PIN-Wert auf.

**Nicht durchgespielt:** der Server-Roundtrip im Erfolgsfall der Freigabe — die PIN des
Test-Managers ist bcrypt-gehasht und nicht rekonstruierbar. Der Aufruf selbst ist unveränderter
Code, und dass er den Server erreicht, belegen beide Fehlerfälle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
