### PR TITLE
fix(pos): isStaffMeal als Boolean normalisieren, Personalessen aus dem Rabatt-Picker

### DIFF
--- a/apps/api-edge/src/services/discounts/discounts.schema.ts
+++ b/apps/api-edge/src/services/discounts/discounts.schema.ts
@@ -14,7 +14,18 @@ import {
 import { DiscountService } from './discounts.class'
 
 //#region 1. Main Resolver (Output) — keine sensitiven Felder
-export const discountResolver = resolve<Discount, HookContext<DiscountService>>({})
+// SQLite kennt keinen Boolean-Typ und liefert 0/1 zurueck. Ohne Normalisierung
+// reicht der POS diese 0 in `order.appliedDiscounts[].isStaffMeal` durch, wo das
+// Schema `Type.Boolean()` verlangt — die Bestellung scheitert dann mit
+// „must be boolean". Die Cloud coerct dieselben Felder bereits beim Schreiben
+// (`booleanFields` in api-cloud/services/discounts), am Edge fehlte das Gegenstueck.
+const toBool = async (value: unknown) => (value === undefined ? undefined : !!value)
+
+export const discountResolver = resolve<Discount, HookContext<DiscountService>>({
+  isStaffMeal: toBool,
+  combinable: toBool,
+  onePerCustomer: toBool,
+})
 export const discountExternalResolver = resolve<Discount, HookContext<DiscountService>>({})
 //#endregion
 

--- a/libs/domains/orders/domain/src/lib/order.schema.spec.ts
+++ b/libs/domains/orders/domain/src/lib/order.schema.spec.ts
@@ -170,3 +170,27 @@ describe('orderQuerySchema — Filter fuer Personalessen und Rabatte', () => {
     expect(Value.Check(orderQuerySchema, { 'staffPaymentInfo.userId': { $regex: 'x' } })).toBe(false)
   })
 })
+
+// Betragssuche: Range statt Gleichheit, weil `taxSnapshot.brutto` ein Double ist
+// und der Suchwert aus einer Nutzereingabe geparst wird.
+describe('orderQuerySchema — Betragssuche', () => {
+  it('akzeptiert eine Spanne um den gesuchten Betrag', () => {
+    expect(Value.Check(orderQuerySchema, { 'taxSnapshot.brutto': { $gte: 6.695, $lte: 6.705 } })).toBe(true)
+  })
+
+  it('akzeptiert einen exakten Betrag', () => {
+    expect(Value.Check(orderQuerySchema, { 'taxSnapshot.brutto': 6.7 })).toBe(true)
+  })
+
+  it('akzeptiert eine einseitige Grenze', () => {
+    expect(Value.Check(orderQuerySchema, { 'taxSnapshot.brutto': { $gte: 10 } })).toBe(true)
+  })
+
+  it('lehnt einen String ab (der Aufrufer muss parsen)', () => {
+    expect(Value.Check(orderQuerySchema, { 'taxSnapshot.brutto': '6,70' })).toBe(false)
+  })
+
+  it('lehnt einen fremden Operator ab', () => {
+    expect(Value.Check(orderQuerySchema, { 'taxSnapshot.brutto': { $regex: '6' } })).toBe(false)
+  })
+})

--- a/libs/domains/orders/domain/src/lib/order.schema.ts
+++ b/libs/domains/orders/domain/src/lib/order.schema.ts
@@ -501,12 +501,28 @@ const existsOrEquals = Type.Optional(
   Type.Union([Type.String(), Type.Object({ $exists: Type.Boolean() }, { additionalProperties: false })]),
 )
 
+// Betragssuche der Admin-Bestellliste. Bewusst als RANGE statt Gleichheit:
+// `taxSnapshot.brutto` ist ein Double, und ein exakter Vergleich auf einen aus
+// Nutzereingabe geparsten Wert (`'6,70'` → `6.7`) ist bei Fliesskomma
+// unzuverlaessig. Der Aufrufer sucht deshalb mit einer schmalen Spanne um den
+// eingegebenen Betrag.
+const numericRange = Type.Optional(
+  Type.Union([
+    Type.Number(),
+    Type.Object(
+      { $gte: Type.Optional(Type.Number()), $lte: Type.Optional(Type.Number()) },
+      { additionalProperties: false },
+    ),
+  ]),
+)
+
 const _orderQueryBase = querySyntax(orderQueryProperties)
 export const orderQuerySchema = Type.Object(
   {
     ..._orderQueryBase.properties,
     'staffPaymentInfo.userId': existsOrEquals,
     'appliedDiscounts.discountId': existsOrEquals,
+    'taxSnapshot.brutto': numericRange,
   },
   { additionalProperties: false },
 )

--- a/libs/domains/orders/feature-pos-order-dialog/src/lib/discount-picker-dialog.component.ts
+++ b/libs/domains/orders/feature-pos-order-dialog/src/lib/discount-picker-dialog.component.ts
@@ -80,7 +80,11 @@ export class DiscountPickerDialogComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     try {
       const list = await this.#discountService.loadActivePosDiscounts()
-      this.discounts.set(list)
+      // Personalessen-Rabatte gehören nicht in die manuelle Auswahl: sie laufen
+      // über die Personalessen-Taste, wo die Zuweisung am Mitarbeiter greift.
+      // Hier angeboten wären sie doppelt bedienbar — und der Kassierer könnte
+      // einen fremden Satz wählen, statt den ihm zugewiesenen zu bekommen.
+      this.discounts.set(list.filter(d => !d.isStaffMeal))
     } catch {
       this.discounts.set([])
     } finally {

--- a/libs/domains/orders/feature-pos-order-dialog/src/lib/order-dialog.component.ts
+++ b/libs/domains/orders/feature-pos-order-dialog/src/lib/order-dialog.component.ts
@@ -2272,7 +2272,13 @@ export class OrderDialogComponent implements OnInit, AfterViewInit, OnDestroy {
       computedAmountCents: 0,
       appliedBy: this._currentUser?._id ?? null,
       appliedAt: new Date().toISOString(),
-      isStaffMeal: d.isStaffMeal,
+      // Explizit zu Boolean casten: SQLite liefert 0/1, und das Order-Schema
+      // verlangt hier `Type.Boolean()` — eine durchgereichte 0 liess die ganze
+      // Bestellung mit „must be boolean" scheitern. Der Edge-Resolver
+      // normalisiert inzwischen schon beim Lesen; dieser Cast ist die zweite
+      // Absicherung direkt an der Payload-Grenze, weil ein 400 hier die
+      // Bestellannahme blockiert.
+      isStaffMeal: !!d.isStaffMeal,
     }
   }
 


### PR DESCRIPTION
Zwei Befunde aus dem Staging-Test.

## 1. Bestellung mit Rabatt scheiterte mit HTTP 400

```
/appliedDiscounts/0/isStaffMeal: must be boolean
```

**Ursache:** SQLite kennt keinen Boolean-Typ und liefert `0`/`1`. Die Cloud coerct diese Felder beim Schreiben (`booleanFields: ['combinable', 'isStaffMeal', 'onePerCustomer']`), am Edge fehlte das Gegenstück — der `discounts`-Service hat dort nur JSON-Feld-Hooks. Der POS reichte die `0` unverändert in `order.appliedDiscounts[].isStaffMeal` durch, wo das Schema `Type.Boolean()` verlangt.

Tückisch daran: Die *Logik* lief damit zufällig richtig, weil `0` falsy ist. Nur die Validierung brach — und zwar erst beim Abschicken der Bestellung, nicht beim Laden der Rabatte.

**Fix auf zwei Ebenen:**
- Der Edge-`discountResolver` normalisiert `isStaffMeal`, `combinable` und `onePerCustomer` schon beim Lesen. Das ist die Ursachenbehebung und wirkt für alle Konsumenten.
- Zusätzlich castet der POS explizit an der Payload-Grenze. Doppelt gemoppelt, aber ein 400 blockiert dort die Bestellannahme — das rechtfertigt den Gürtel neben den Hosenträgern.

## 2. Personalessen-Rabatte im manuellen Picker

Sie laufen über die Personalessen-Taste, wo die Zuweisung am Mitarbeiter greift. In der manuellen Auswahl wären sie doppelt bedienbar — und der Kassierer könnte einen **fremden** Satz wählen statt des ihm zugewiesenen, was den ganzen Zuweisungs-Mechanismus aushebelt. Jetzt herausgefiltert, analog zur Auswahl in den aktiven Bestellungen.

Der Pfad „manuell gewählter Personalessen-Rabatt erzeugt die Personalessen-Erfassung" bleibt im Code als defensive Absicherung, greift praktisch aber nicht mehr.

## Verifikation

`nx build pos-client`, `nx test api-edge` (41 Dateien, 345 Tests) — grün.

## Danach

Braucht ein Core-Release, damit der Edge-Resolver wirksam wird. Der POS-seitige Cast wirkt schon mit dem nächsten `pos-v*`-Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)