### PR TITLE
feat(api-edge): Gerätezählung im Cloud-Heartbeat mitsenden

### DIFF
--- a/apps/api-edge/src/workers/cloud-sync-scheduler.worker.ts
+++ b/apps/api-edge/src/workers/cloud-sync-scheduler.worker.ts
@@ -35,6 +35,7 @@ import {
 import { recordSyncRun, type RecordSyncRunInput } from '../services/sync-runs/record-sync-run.helper'
 import { printServerManager } from '../print-server'
 import { applyPulledRecords, cloudFetch, extractAjvValidationErrors, PULL_PAGE_SIZE } from './sync-apply'
+import { collectDeviceCountsForHeartbeat } from './heartbeat-device-counts'
 import {
   SyncRunDirection,
   SyncRunOutcome,
@@ -1025,12 +1026,17 @@ const runHeartbeat = async (app: Application, connection: CloudConnection): Prom
   const cloudToken = decryptCloudToken(connection.cloudToken)
   if (!cloudToken) return null
   const startMonotonic = performance.now()
+  // Vor dem Fetch ermitteln und vollstaendig fehler-isoliert (liefert im
+  // Zweifel null): ein Fehler hier duerfte niemals den Heartbeat scheitern
+  // lassen — drei Fehlschlaege aktivieren den Notfall-Modus der Edge.
+  const deviceConnections = await collectDeviceCountsForHeartbeat(app, connection.tenantId)
   const response = await cloudFetch(connection.cloudUrl, cloudToken, '/sync-heartbeat', {
     method: 'POST',
     body: JSON.stringify({
       edgeTimestamp: new Date().toISOString(),
       edgeClockMonotonicMs: Math.round(startMonotonic),
       edgeVersion: APP_VERSION,
+      ...(deviceConnections ? { deviceConnections } : {}),
     }),
     timeoutMs: HEARTBEAT_TIMEOUT_MS,
   })

--- a/apps/api-edge/src/workers/heartbeat-device-counts.spec.ts
+++ b/apps/api-edge/src/workers/heartbeat-device-counts.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { logger } from '@panary/shared-backend'
+
+import { collectDeviceCountsForHeartbeat } from './heartbeat-device-counts'
+
+vi.mock('@panary/shared-backend', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test-Mock der Feathers-App.
+const makeApp = (find: (params: unknown) => unknown): any => ({
+  service: (path: string) => {
+    if (path !== 'device-connections') throw new Error(`unexpected service ${path}`)
+    return { find }
+  },
+})
+
+describe('collectDeviceCountsForHeartbeat', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('liefert die Zählwerte des device-connections-Service', async () => {
+    const app = makeApp(async () => ({ online: 2, total: 3, connectedDeviceIds: ['a', 'b'] }))
+
+    const counts = await collectDeviceCountsForHeartbeat(app, 't1')
+
+    // connectedDeviceIds wird bewusst verworfen — die Cloud kann Edge-deviceIds
+    // nicht auflösen, und eine Liste wäre eine unbegrenzt wachsende Nutzlast.
+    expect(counts).toEqual({ online: 2, total: 3 })
+  })
+
+  it('ruft den Service intern und mit Tenant-Kontext auf', async () => {
+    const find = vi.fn(async () => ({ online: 0, total: 0 }))
+    await collectDeviceCountsForHeartbeat(makeApp(find), 't1')
+
+    // provider: undefined ist Pflicht — sonst greifen authenticate/authorize
+    // und der Worker bekäme 403 statt Zahlen.
+    expect(find).toHaveBeenCalledWith({ provider: undefined, user: { tenantId: 't1' } })
+  })
+
+  it('liefert null ohne tenantId, ohne den Service anzufassen', async () => {
+    const find = vi.fn()
+    expect(await collectDeviceCountsForHeartbeat(makeApp(find), undefined)).toBeNull()
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('FAILURE-ISOLATION: wirft nie, sondern liefert null und loggt', async () => {
+    // Der wichtigste Test dieser Datei. runHeartbeat trägt die Token-Rotation,
+    // und drei Fehlschläge aktivieren den Notfall-Modus der Edge — eine
+    // Telemetrie-Nebensache darf das niemals auslösen.
+    const app = makeApp(async () => {
+      throw new Error('SQLITE_BUSY')
+    })
+
+    await expect(collectDeviceCountsForHeartbeat(app, 't1')).resolves.toBeNull()
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'sync.heartbeat.device_counts_failed' }),
+    )
+  })
+
+  it('liefert null bei unvollständiger Service-Antwort, statt einen halben Report zu senden', async () => {
+    expect(
+      await collectDeviceCountsForHeartbeat(
+        makeApp(async () => ({ online: 2 })),
+        't1',
+      ),
+    ).toBeNull()
+    expect(
+      await collectDeviceCountsForHeartbeat(
+        makeApp(async () => undefined),
+        't1',
+      ),
+    ).toBeNull()
+  })
+})

--- a/apps/api-edge/src/workers/heartbeat-device-counts.ts
+++ b/apps/api-edge/src/workers/heartbeat-device-counts.ts
@@ -1,0 +1,54 @@
+import { logger } from '@panary/shared-backend'
+
+import type { Application } from '../declarations'
+
+/**
+ * Ermittelt die Geraetezaehlung des Edge fuer den Cloud-Heartbeat.
+ *
+ * Der Edge weiss laengst, welche POS-Clients bei ihm haengen (Channel-Registry,
+ * s. services/device-connections). Die Cloud kann es nicht wissen: die Clients
+ * verbinden sich gegen den Edge, nie gegen die Cloud. Ohne diese Meldung zeigt
+ * das Admin-Dashboard bei Edge-Kunden dauerhaft „0 verbunden", waehrend im Laden
+ * verkauft wird.
+ *
+ * ⚠️ FAILURE-ISOLATION IST PFLICHT, nicht Hoeflichkeit.
+ * `runHeartbeat` ist der Lebensnerv des Edge: Er traegt die Token-Rotation, und
+ * drei aufeinanderfolgende Fehlschlaege (bzw. fuenf Minuten ohne OK) aktivieren
+ * den Notfall-Modus der gesamten Edge. Diese Funktion darf deshalb unter keinen
+ * Umstaenden werfen — im Zweifel `null` liefern und den Heartbeat ohne die
+ * Telemetrie fliegen lassen. Eine Anzeige-Nebensache darf niemals den Sync
+ * gefaehrden.
+ */
+export const collectDeviceCountsForHeartbeat = async (
+  app: Application,
+  tenantId: string | undefined,
+): Promise<{ online: number; total: number } | null> => {
+  if (!tenantId) return null
+  try {
+    // Ueber den bestehenden Service statt einer zweiten Zaehl-Implementierung:
+    // er kapselt zusaetzlich die `total`-Ermittlung inkl. Degradationspfad
+    // (DB-Fehler → total faellt auf online zurueck). Interner Call
+    // (`provider: undefined`) passiert `authenticate` und `authorize()` —
+    // letzteres steigt ohne provider frueh aus.
+    const res = (await (app as any).service('device-connections').find({
+      provider: undefined,
+      user: { tenantId },
+    })) as { online?: number; total?: number } | undefined
+
+    const online = res?.online
+    const total = res?.total
+    if (typeof online !== 'number' || typeof total !== 'number') return null
+
+    // `connectedDeviceIds` wird bewusst verworfen: die Cloud kann Edge-deviceIds
+    // nicht aufloesen (Edge-Geraete stehen in keiner Sync-Allowlist), und eine
+    // Liste waere eine unbegrenzt wachsende Nutzlast statt zweier Integer.
+    return { online, total }
+  } catch (err) {
+    logger.warn({
+      message: 'Geraetezaehlung fuer Heartbeat nicht ermittelbar — Heartbeat laeuft ohne',
+      event: 'sync.heartbeat.device_counts_failed',
+      errorMessage: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
+}

--- a/docs/domains/geraete-online-tracking.md
+++ b/docs/domains/geraete-online-tracking.md
@@ -67,6 +67,36 @@ keine Änderung). Andere Rollen: KPI „–", kein Badge, Liste leer (403 → gr
 Live-Zählung pro Edge-Prozess (am Edge der Normalfall — Single-Instance). `lastSeen`
 liefert zusätzlich „letzte Aktivität" als DB-Record.
 
+## Speist zusaetzlich den Cloud-Heartbeat (seit 2026-07-30)
+
+Die Cloud kann die POS-Clients eines Edge-Kunden nicht sehen: sie halten ihren
+Socket zum Edge, nie zur Cloud, und `devices` steht in keiner Sync-Allowlist.
+Das Admin-Dashboard zeigte deshalb dauerhaft „0 verbunden", waehrend im Laden
+verkauft wurde.
+
+`collectDeviceCountsForHeartbeat`
+([`workers/heartbeat-device-counts.ts`](../../apps/api-edge/src/workers/heartbeat-device-counts.ts))
+ruft diesen Service intern (`provider: undefined`) und legt `{ online, total }`
+als `deviceConnections` in den `/sync-heartbeat`-Payload.
+
+Zwei Eigenschaften sind nicht verhandelbar:
+
+- **`connectedDeviceIds` geht NICHT in die Cloud.** Die Cloud koennte
+  Edge-`deviceId`s ohnehin nicht aufloesen, und eine Liste waere eine unbegrenzt
+  wachsende Nutzlast statt zweier Integer.
+- **Failure-Isolation.** Die Ermittlung laeuft vollstaendig in `try/catch` und
+  liefert im Zweifel `null`. `runHeartbeat` traegt die Token-Rotation, und drei
+  Fehlschlaege (bzw. fuenf Minuten ohne OK) aktivieren den **Notfall-Modus der
+  gesamten Edge** — eine Telemetrie-Nebensache darf das nie ausloesen.
+
+Kadenz und damit Frische haengen am Sync-Modus: `AUTO` alle 5 min (bis 60 min
+einstellbar), `SCHEDULED` nur an den Slots, `MANUAL` alle 30 min, `DISABLED`
+nie. Die Cloud bewertet das entsprechend und rechnet einen fehlenden oder alten
+Report nie als `0`.
+
+Entscheidung, Begruendung und Sicherheitskontext:
+`panary-cloud/docs/adr/0030-edge-geraetezaehlung-ueber-heartbeat.md`.
+
 ## Verwandt
 - Cloud-Pendant: `panary-cloud/docs/architecture/geraete-online-tracking.md`
 - [Cloud-Status-Badge](../architecture/cloud-status-badge.md)

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,9 @@
 # Wiki Update Log
 
+## 2026-07-30
+
+* **Update**: [Geräte-Online-Tracking](domains/geraete-online-tracking.md) — der `device-connections`-Service speist jetzt zusätzlich den Cloud-Heartbeat: `collectDeviceCountsForHeartbeat` legt `{ online, total }` als `deviceConnections` in den `/sync-heartbeat`-Payload, damit das Admin-Dashboard die am Edge hängenden POS-Clients überhaupt sehen kann (bisher zeigte es bei Edge-Kunden dauerhaft „0 verbunden“). Zwei nicht verhandelbare Eigenschaften dokumentiert: `connectedDeviceIds` geht **nicht** in die Cloud (nicht auflösbar, unbegrenzt wachsende Nutzlast), und die Ermittlung ist vollständig fehler-isoliert — `runHeartbeat` trägt die Token-Rotation, und drei Fehlschläge aktivieren den Notfall-Modus der gesamten Edge. Entscheidung und Sicherheitskontext liegen als ADR 0030 im Cloud-Wiki.
+
 ## 2026-07-29
 
 * **Update**: [Rabatte](domains/rabatte.md) — Personalessen-Abschnitt erweitert: Welcher Nachlass gilt, steht jetzt als Referenz am Benutzer (`user.staffMealDiscountId`) statt als eingefrorene Wertkopie in `user.discountDetails`; der Bestelldialog löst sie beim Erfassen gegen den lokalen Rabatt-Bestand auf und fällt bei toter Referenz auf „ohne Nachlass" zurück, statt die Bestellung abzulehnen. Neu dokumentiert ist außerdem die Invariante „Personalessen ist rabatt-exklusiv" (`pricing/staff-meal-exclusivity.ts`), durchgesetzt vom Edge-Hook `validateStaffMealExclusivity` (create + patch, merged Vorzustand + Body) und der POS-UI; `applyAutomaticDiscounts` überspringt Personalessen-Bestellungen jetzt, statt einen Rabatt einzusammeln, an dem die Bestellung anschließend scheitert. Cloud-Seite (Standard, Vorbelegung, Rechte): `panary-cloud/docs/domains/personalessen-rabatt.md`.

--- a/libs/domains/sync/domain/src/lib/sync-heartbeat.schema.ts
+++ b/libs/domains/sync/domain/src/lib/sync-heartbeat.schema.ts
@@ -12,6 +12,32 @@ export const syncHeartbeatRequestSchema = Type.Object(
     edgeClockMonotonicMs: Type.Number({ minimum: 0 }),
     edgeVersion: Type.Optional(Type.String({ maxLength: 50 })),
     outboxBacklog: Type.Optional(Type.Integer({ minimum: 0 })),
+    // Geraetezaehlung des Edge-LAN (POS/KDS am Edge). Die Cloud kennt diese
+    // Clients nicht — sie halten ihren Socket zum Edge, nie zur Cloud — und
+    // kann sie ohne diese Meldung nicht anzeigen.
+    //
+    // Verschachtelt statt flach (anders als `outboxBacklog`), weil die zwei
+    // Zahlen nur GEMEINSAM interpretierbar sind: kaeme nur `online` durch,
+    // muesste die Cloud einen halben Report verarbeiten. Das Type.Object macht
+    // die Praesenz atomar.
+    //
+    // ⚠️ Dieses Schema ist auf dem Heartbeat-Pfad KEIN Laufzeit-Gate, sondern
+    // Typ- und Dokumentationswert: api-cloud registriert `sync-heartbeat`
+    // bewusst ohne `validateData`. Das ist kein Versehen — ein 400 im Heartbeat
+    // zaehlt am Edge `consecutiveHeartbeatFailures` hoch und aktiviert nach drei
+    // Fehlversuchen bzw. fuenf Minuten den Notfall-Modus. Eine
+    // Schema-Verschaerfung wuerde die Kundenflotte umlegen statt einen Wert
+    // abzulehnen. Die verbindliche Pruefung sitzt in der Cloud
+    // (services/sync/edge-device-counts.ts).
+    deviceConnections: Type.Optional(
+      Type.Object(
+        {
+          online: Type.Integer({ minimum: 0, maximum: 1000 }),
+          total: Type.Integer({ minimum: 0, maximum: 1000 }),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   },
   { $id: 'SyncHeartbeatRequest', additionalProperties: false },
 )


### PR DESCRIPTION
Die Cloud kann die POS-Clients eines Edge-Kunden nicht sehen: sie halten ihren Socket zum Edge, nie zur Cloud, und `devices` steht in keiner Sync-Allowlist. Das Admin-Dashboard zeigte deshalb dauerhaft „0 verbunden", während im Laden verkauft wurde.

Der Edge kennt die Zahl längst — `device-connections` zählt die `authenticated`-Channel-Connections live aus. Diese PR ist die **Sendeseite**: vier Zeilen im Heartbeat-Payload, der Rest ist Isolation.

Empfangs- und Anzeigeseite: `panary-cloud#43`. Entscheidung + Sicherheitskontext: ADR 0030 im Cloud-Wiki.

## Warum das meiste hier Isolation ist

`runHeartbeat` ist der Lebensnerv des Edge: Er trägt die Token-Rotation, und **drei aufeinanderfolgende Fehlschläge — bzw. fünf Minuten ohne OK — aktivieren den Notfall-Modus der gesamten Edge**. Eine Telemetrie-Nebensache darf das unter keinen Umständen auslösen.

Deshalb:

- Die Ermittlung liegt in einem eigenen Modul, läuft vollständig in `try/catch` und liefert im Zweifel `null`. Der Heartbeat fliegt dann ohne die Telemetrie weiter.
- Sie läuft **vor** dem `cloudFetch`, nicht mittendrin.
- Eigenes Modul auch deshalb, weil `cloud-sync-scheduler.worker.ts` 1865 Zeilen hat und **keine** Spec besitzt — anders wäre der Code nicht testbar. Der wichtigste Test der neuen Spec ist genau die Failure-Isolation.

## Was bewusst nicht gesendet wird

`connectedDeviceIds` wird verworfen. Die Cloud könnte Edge-`deviceId`s ohnehin nicht auflösen (Edge-Geräte stehen in keiner Sync-Allowlist), und eine Liste wäre eine unbegrenzt wachsende Nutzlast statt zweier Integer — bei einer Quelle, die Kundenhardware ist.

## Zum Schema-Feld

`deviceConnections` ist verschachtelt (anders als das benachbarte `outboxBacklog`), weil die zwei Zahlen nur **gemeinsam** interpretierbar sind: käme nur `online` durch, müsste die Cloud einen halben Report verarbeiten. `Type.Object` macht die Präsenz atomar.

Der Kommentar dort hält fest, dass dieses Schema auf dem Heartbeat-Pfad **kein Laufzeit-Gate** ist: api-cloud registriert `sync-heartbeat` bewusst ohne `validateData`, weil ein `400` dort die Flotte in den Notfall-Modus kippen würde. Die verbindliche Prüfung sitzt in der Cloud.

## Rollout — bitte NACH panary-cloud#43

Ein `v*`-Tag in diesem Repo baut `panary-edge:latest` und rollt via Watchtower **binnen ~1 h ungegatet auf alle Kunden-Edges** aus; einen Staging-Kanal gibt es hier nicht. Deshalb zuerst die Cloud deployen (dort ändert sich sichtbar nichts, aber die Härtung ist scharf), dann dieses Repo taggen.

Kein Pin-Bump nötig: die Cloud liest das Feld untypisiert und ist von diesem Release entkoppelt.

## Gegengeprüft

`nx affected -t test,build` grün (350 + 25 Tests), `nx format:check` sauber. Für `api-edge`/`sync-domain` existiert kein `lint`-Target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)