### PR TITLE
feat(rbac): AppResource MEAL_SETTLEMENTS + Matrix-Regeln für die Sammelabrechnung

### DIFF
--- a/libs/domains/users/domain/src/lib/permissions.spec.ts
+++ b/libs/domains/users/domain/src/lib/permissions.spec.ts
@@ -45,3 +45,16 @@ describe('AppResource — Phase 6 (BRAND + RESERVATION)', () => {
     })
   })
 })
+
+describe('AppResource — MEAL_SETTLEMENTS', () => {
+  // Der Wert MUSS exakt dem Service-Pfad entsprechen: authorize() leitet die
+  // Resource aus `context.path` ab. Ein Tippfehler ergibt 403 fuer alle
+  // Tenant-Rollen, ohne dass der Service selbst auffaellig waere.
+  it('exportiert MEAL_SETTLEMENTS mit Wert "meal-settlements"', () => {
+    expect(AppResource.MEAL_SETTLEMENTS).toBe('meal-settlements')
+  })
+
+  it('CASH_SESSIONS bleibt unveraendert "cash-sessions"', () => {
+    expect(AppResource.CASH_SESSIONS).toBe('cash-sessions')
+  })
+})

--- a/libs/domains/users/domain/src/lib/permissions.ts
+++ b/libs/domains/users/domain/src/lib/permissions.ts
@@ -177,6 +177,16 @@ export const AppResource = {
    *  TENANT_OWNER/MANAGER/TECHNICIAN: MANAGE. TENANT_STAFF: READ+CREATE+UPDATE
    *  (öffnen/zählen/schließen — Self-Scope für fremde Sessions später). */
   CASH_SESSIONS: 'cash-sessions',
+  /** Cloud-only: Sammelabrechnung offener Personal- und Firmenkundenessen
+   *  (append-only Belegdokument, Korrektur laeuft ueber eine Gegenbuchung).
+   *  Methoden: find/get/create + Custom-Method `openItems` (READ).
+   *  TENANT_OWNER/MANAGER/TECHNICIAN: READ+CREATE. TENANT_STAFF: KEIN Eintrag —
+   *  die Offen-Sicht zeigt die Verzehrhistorie aller Kollegen mit Namen und
+   *  Betraegen (Mitbestimmung/Datenschutz, siehe panary-cloud
+   *  docs/domains/personalessen-abrechnung-plan.md §4.7).
+   *  Bewusst KEIN MANAGE: das deckt jede Aktion ab, auch ein spaeter
+   *  nachgeruestetes `patch` — die Append-only-Zusage waere damit still weg. */
+  MEAL_SETTLEMENTS: 'meal-settlements',
   USER_PREFERENCES: 'user-preferences',
   DEVICES: 'devices',
   /** Cloud-only: Live-Zählung der aktuell mit der Cloud verbundenen Geräte

--- a/libs/domains/users/domain/src/lib/roles.matrix.spec.ts
+++ b/libs/domains/users/domain/src/lib/roles.matrix.spec.ts
@@ -54,12 +54,9 @@ describe('RolePermissions — Phase 6 (BRAND + RESERVATION)', () => {
     for (const resource of newResources) {
       it(`hat CREATE+READ+UPDATE+DELETE auf ${resource}`, () => {
         const actions = roleActions(UserSystemRole.TENANT_OWNER, resource)
-        expect(actions).toEqual(expect.arrayContaining([
-          AppAction.CREATE,
-          AppAction.READ,
-          AppAction.UPDATE,
-          AppAction.DELETE,
-        ]))
+        expect(actions).toEqual(
+          expect.arrayContaining([AppAction.CREATE, AppAction.READ, AppAction.UPDATE, AppAction.DELETE]),
+        )
       })
     }
   })
@@ -68,12 +65,9 @@ describe('RolePermissions — Phase 6 (BRAND + RESERVATION)', () => {
     for (const resource of newResources) {
       it(`hat CREATE+READ+UPDATE+DELETE auf ${resource}`, () => {
         const actions = roleActions(UserSystemRole.TENANT_MANAGER, resource)
-        expect(actions).toEqual(expect.arrayContaining([
-          AppAction.CREATE,
-          AppAction.READ,
-          AppAction.UPDATE,
-          AppAction.DELETE,
-        ]))
+        expect(actions).toEqual(
+          expect.arrayContaining([AppAction.CREATE, AppAction.READ, AppAction.UPDATE, AppAction.DELETE]),
+        )
       })
     }
   })
@@ -112,12 +106,9 @@ describe('RolePermissions — Phase 6 (BRAND + RESERVATION)', () => {
     for (const resource of newResources) {
       it(`hat CREATE+READ+UPDATE+DELETE auf ${resource}`, () => {
         const actions = roleActions(UserSystemRole.PLATFORM_ADMIN, resource)
-        expect(actions).toEqual(expect.arrayContaining([
-          AppAction.CREATE,
-          AppAction.READ,
-          AppAction.UPDATE,
-          AppAction.DELETE,
-        ]))
+        expect(actions).toEqual(
+          expect.arrayContaining([AppAction.CREATE, AppAction.READ, AppAction.UPDATE, AppAction.DELETE]),
+        )
       })
     }
   })
@@ -136,9 +127,7 @@ describe('RolePermissions — Phase 6 (BRAND + RESERVATION)', () => {
     it('TENANT_OWNER hat MANAGE auf USERS', () => {
       const rules = RolePermissions[UserSystemRole.TENANT_OWNER] as PermissionRule[]
       expect(rules).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ resource: AppResource.USERS, action: AppAction.MANAGE }),
-        ]),
+        expect.arrayContaining([expect.objectContaining({ resource: AppResource.USERS, action: AppAction.MANAGE })]),
       )
     })
 
@@ -158,7 +147,9 @@ describe('RolePermissions — Phase 6 (BRAND + RESERVATION)', () => {
         expect(roleCan(role, AppResource.STOREFRONT_PUBLISH_ROLLBACK, AppAction.CREATE)).toBe(true)
       }
       expect(roleCan(UserSystemRole.TENANT_STAFF, AppResource.STOREFRONT_PUBLISH_BRAND, AppAction.CREATE)).toBe(false)
-      expect(roleCan(UserSystemRole.TENANT_STAFF, AppResource.STOREFRONT_PUBLISH_ROLLBACK, AppAction.CREATE)).toBe(false)
+      expect(roleCan(UserSystemRole.TENANT_STAFF, AppResource.STOREFRONT_PUBLISH_ROLLBACK, AppAction.CREATE)).toBe(
+        false,
+      )
     })
   })
 
@@ -183,5 +174,41 @@ describe('RolePermissions — Phase 6 (BRAND + RESERVATION)', () => {
         expect(roleActions(role, AppResource.PLATFORM_USERS)).toEqual([])
       }
     })
+  })
+})
+
+describe('RolePermissions — MEAL_SETTLEMENTS (Sammelabrechnung offener Personalessen)', () => {
+  const allowedRoles = [UserSystemRole.TENANT_OWNER, UserSystemRole.TENANT_MANAGER, UserSystemRole.TENANT_TECHNICIAN]
+
+  for (const role of allowedRoles) {
+    it(`${role} hat genau READ + CREATE`, () => {
+      expect(roleActions(role, AppResource.MEAL_SETTLEMENTS).sort()).toEqual([AppAction.CREATE, AppAction.READ].sort())
+    })
+
+    // Append-only: der Beleg wird nie geaendert oder geloescht, Korrektur laeuft
+    // ueber eine Gegenbuchung. MANAGE waere hier still eine Zusagen-Aufweichung.
+    it(`${role} hat KEIN UPDATE und KEIN DELETE`, () => {
+      expect(roleCan(role, AppResource.MEAL_SETTLEMENTS, AppAction.UPDATE)).toBe(false)
+      expect(roleCan(role, AppResource.MEAL_SETTLEMENTS, AppAction.DELETE)).toBe(false)
+    })
+  }
+
+  // Die Offen-Sicht zeigt die Verzehrhistorie aller Kollegen mit Namen und
+  // Betraegen — Mitbestimmung/Datenschutz, siehe panary-cloud
+  // docs/domains/personalessen-abrechnung-plan.md §4.7.
+  it('TENANT_STAFF hat keinerlei Zugriff', () => {
+    expect(roleActions(UserSystemRole.TENANT_STAFF, AppResource.MEAL_SETTLEMENTS)).toEqual([])
+  })
+
+  it('Platform- und Geraete-Rollen haben keinerlei Zugriff', () => {
+    const blockedRoles = [
+      UserSystemRole.PLATFORM_ADMIN,
+      UserSystemRole.PLATFORM_SUPPORT,
+      UserSystemRole.DEVICE_POS,
+      UserSystemRole.DEVICE_TABLET,
+    ]
+    for (const role of blockedRoles) {
+      expect(roleActions(role, AppResource.MEAL_SETTLEMENTS)).toEqual([])
+    }
   })
 })

--- a/libs/domains/users/domain/src/lib/roles.matrix.ts
+++ b/libs/domains/users/domain/src/lib/roles.matrix.ts
@@ -334,6 +334,9 @@ export const RolePermissions: Record<UserSystemRole, PermissionRule[]> = {
     { resource: AppResource.BUSINESS_DAY_REPORTS, action: AppAction.MANAGE },
     { resource: AppResource.BUSINESS_DAY_REPORT_EVENTS, action: AppAction.READ },
     { resource: AppResource.CASH_SESSIONS, action: AppAction.MANAGE },
+    // Sammelabrechnung: lesen + anlegen. KEIN MANAGE — der Beleg ist append-only,
+    // Korrektur laeuft ueber eine Gegenbuchung (create mit `reversalOf`).
+    { resource: AppResource.MEAL_SETTLEMENTS, action: [AppAction.READ, AppAction.CREATE] },
     { resource: AppResource.USER_PREFERENCES, action: AppAction.MANAGE },
     { resource: AppResource.DEVICES, action: AppAction.MANAGE },
     // Live-Verbindungszählung der Geräte (Socket-Registry) — read-only.
@@ -539,6 +542,7 @@ export const RolePermissions: Record<UserSystemRole, PermissionRule[]> = {
     { resource: AppResource.BUSINESS_DAY_REPORTS, action: AppAction.MANAGE },
     { resource: AppResource.BUSINESS_DAY_REPORT_EVENTS, action: AppAction.READ },
     { resource: AppResource.CASH_SESSIONS, action: AppAction.MANAGE },
+    { resource: AppResource.MEAL_SETTLEMENTS, action: [AppAction.READ, AppAction.CREATE] },
     { resource: AppResource.USER_PREFERENCES, action: AppAction.MANAGE },
     { resource: AppResource.DEVICES, action: AppAction.MANAGE },
     // Live-Verbindungszählung der Geräte (Socket-Registry) — read-only.
@@ -676,6 +680,8 @@ export const RolePermissions: Record<UserSystemRole, PermissionRule[]> = {
     { resource: AppResource.BUSINESS_DAY_REPORTS, action: AppAction.MANAGE },
     { resource: AppResource.BUSINESS_DAY_REPORT_EVENTS, action: AppAction.READ },
     { resource: AppResource.CASH_SESSIONS, action: AppAction.MANAGE },
+    // Sammelabrechnung: der Filialleiter ist der eigentliche Nutzer.
+    { resource: AppResource.MEAL_SETTLEMENTS, action: [AppAction.READ, AppAction.CREATE] },
     { resource: AppResource.USER_PREFERENCES, action: AppAction.MANAGE },
     { resource: AppResource.SHIFTS, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_TEMPLATES, action: AppAction.MANAGE },


### PR DESCRIPTION
Core-Runde 1 aus dem [Umsetzungsplan](https://github.com/panary/panary-cloud/blob/main/docs/domains/personalessen-abrechnung-plan.md) — der RBAC-Vorlauf für den Cloud-Service `meal-settlements`.

**Warum vorgezogen:** Ohne Matrix-Eintrag liefert `authorize()` **403 für alle Tenant-Rollen**. Die Ressource muss also im Core-Pin stehen, bevor der Service in panary-cloud entsteht. Bis dahin ist der Eintrag wirkungslos (`authorize()` prüft `context.path`, den es noch nicht gibt) — deshalb risikofrei vorziehbar.

**Warum getrennt vom Rest:** Der Plan bündelte ursprünglich RBAC und Aggregator-Umbau in eine Core-Runde. Das ist die falsche Kopplung — dies hier ist eine additive Enum-/Matrix-Ergänzung mit Risiko ≈ 0, der Aggregator-Umbau verschiebt dagegen Berichtszahlen für alle Tenants ohne Staging-Kanal. Getrennt kostet es einen zusätzlichen Pin-Bump und gibt dafür die lesende Offen-Sicht frei, bevor irgendeine Zahl wandert.

## Rechte

| Rolle | Aktionen |
| --- | --- |
| `TENANT_OWNER`, `TENANT_MANAGER`, `TENANT_TECHNICIAN` | `[READ, CREATE]` |
| `TENANT_STAFF` | **kein Eintrag** |
| Platform- und Geräte-Rollen | **kein Eintrag** |

Zwei bewusste Abweichungen von den Nachbar-Ressourcen:

- **Kein `MANAGE`**, obwohl `CASH_SESSIONS` und `BUSINESS_DAY_REPORTS` es haben. `MANAGE` deckt jede Aktion ab — auch ein später nachgerüstetes `patch`. Die Append-only-Zusage des Belegdokuments wäre damit still weg, ohne dass jemand die Matrix anfasst. Korrekturen laufen über eine Gegenbuchung (`create` mit `reversalOf`).
- **Kein `TENANT_STAFF`.** Die Offen-Sicht zeigt die Verzehrhistorie aller Kollegen mit Namen und Beträgen — Mitbestimmung nach § 87 Abs. 1 Nr. 6 BetrVG und § 26 BDSG (§4.7 des Plans). Eine Eigensicht „meine offenen Posten" ist ein eigenes Feature mit Self-Scope-Hook, kein Matrix-Eintrag.

## Verifikation

- `nx test users-domain` — 125 Tests grün (7 neue in `roles.matrix.spec.ts`, 2 in `permissions.spec.ts`)
- `nx run-many -t build --projects=tag:publishable` — 39 Projekte
- panary-cloud `nx build api-cloud` gegen die frischen dist-Artefakte — grün, der Pin-Bump ist deploybar

Nach dem Merge: Release-Tag (nächste freie Version nach `v26.7.43`), dann Pin-Bump in panary-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)