### PR TITLE
fix(schemas): gestempelte Felder optional, wo es sicher ist (ADR 0031)

### DIFF
--- a/apps/api-edge/src/services/assert-stamp-fields.spec.ts
+++ b/apps/api-edge/src/services/assert-stamp-fields.spec.ts
@@ -139,21 +139,27 @@ describe('assertStampFields() — Sweep ueber registrierte Services', () => {
   })
 })
 
-// REGRESSION 2026-08-01: `apikeys` fuehrt `locationId` als Pflichtfeld im
-// DATA-Schema, obwohl multiTenancy() es stempelt. Solange der Stempel greift
-// (Fix im Hook: activeLocationId-Fallback + Location-Lookup) funktioniert der
-// Endpunkt — faellt er aus, ist die 400-Meldung irrefuehrend. Der Check macht
-// diese Kopplung sichtbar; die Assertion haelt fest, dass sie bekannt ist.
-describe('apikeyDataSchema — echter Befund aus dem Bug vom 2026-08-01', () => {
-  it('locationId ist Pflicht, obwohl multiTenancy es stempelt', () => {
+// REGRESSION 2026-08-01: `apikeys` fuehrte `tenantId`/`locationId` als
+// Pflichtfelder im DATA-Schema, obwohl multiTenancy() sie stempelt. Aus dieser
+// Kopplung entstand der 400 „must have required property 'locationId'", der
+// auf den Client zeigte, obwohl die Ursache serverseitig lag. Die Felder sind
+// inzwischen optional — dieser Test haelt das fest.
+describe('apikeyDataSchema — Schema-Falle aus dem Bug vom 2026-08-01', () => {
+  it('tenantId/locationId sind optional, nicht Pflicht', () => {
     const violation = checkStampFields({
       path: 'apikeys',
       dataSchema: apikeyDataSchema,
       mtOptions: { isolateLocation: true, allowGlobalData: false },
     })
-    expect(violation?.required).toContain('locationId')
-    // Das Feld IST im Schema deklariert — der Cloud-Check (nur MISSING) haette
-    // hier nichts gemeldet. Genau dafuer gibt es die REQUIRED-Regel.
-    expect(violation?.missing).toEqual([])
+    expect(violation).toBeNull()
+  })
+
+  it('die Felder sind weiterhin DEKLARIERT — sonst lehnt AJV den Stempel ab', () => {
+    // Optional heisst nicht „entfernt": das Schema ist geschlossen
+    // (`additionalProperties: false`), ein nicht deklariertes Feld wuerde vom
+    // gestempelten Wert als `additionalProperty` abgelehnt. Genau diese zweite
+    // Falle prueft die MISSING-Regel.
+    const props = (apikeyDataSchema as { properties?: Record<string, unknown> }).properties ?? {}
+    expect(Object.keys(props)).toEqual(expect.arrayContaining(['tenantId', 'locationId']))
   })
 })

--- a/apps/api-edge/src/services/assert-stamp-fields.ts
+++ b/apps/api-edge/src/services/assert-stamp-fields.ts
@@ -42,6 +42,41 @@ type JsonSchemaLike = {
   oneOf?: JsonSchemaLike[]
 }
 
+/**
+ * Services, deren DATA-Schema ein gestempeltes Feld BEWUSST als Pflicht fuehrt.
+ * Ohne diese Liste meldete der Check dieselben bekannten Faelle bei jedem Boot
+ * und die Warnung waere nach der dritten Woche unsichtbar.
+ *
+ * Jeder Eintrag braucht eine Begruendung — „schon immer so" zaehlt nicht.
+ * Wer einen Service hier eintraegt, entscheidet sich fuer eine potenziell
+ * irrefuehrende 400-Meldung; das muss die Alternative aufwiegen.
+ */
+const REQUIRED_STAMP_EXCEPTIONS: Record<string, string> = {
+  // SQLite hat auf BEIDEN Spalten `notNullable` (20260328000004_pre_orders).
+  // Optional zu machen verwandelt einen klaren 400 in einen
+  // `NOT NULL constraint failed`-500 — eine Verschlechterung.
+  'pre-orders': 'DB-Constraint notNullable auf tenantId und locationId',
+  // `locations.tenantId` ist ebenfalls notNullable (20260219000002). Zusaetzlich
+  // ist der einzige externe Create-Pfad der Sync-Pull-Apply, der OHNE `user`
+  // laeuft — dort ist `required` die einzige Instanz, die einen defekten
+  // Cloud-Record laut ablehnt statt ihn still mit NULL zu schreiben.
+  locations: 'DB-Constraint notNullable auf tenantId + Pull-Apply ohne user',
+  // Diese Services sind Ziel des Cloud→Edge-Pull-Apply (`sync-apply.ts`,
+  // `create(..., { provider: undefined, fromSync: true })` — also ohne `user`,
+  // damit ohne Stempel). Faellt `required` weg, landet ein Cloud-Record ohne
+  // locationId still mit NULL in der Edge-DB und ist fuer den filial-gescopten
+  // POS unsichtbar: „gesynct, aber nicht da" ohne jede Fehlermeldung. Der laute
+  // REJECTED-Eintrag im sync-runs-Detail ist die bessere Diagnose.
+  // Lockerung erst zusammen mit einem Guard, der im fromSync-Pfad ein fehlendes
+  // tenantId/locationId hart ablehnt.
+  products: 'Pull-Apply ohne user — required ist der einzige Schutz',
+  'product-groups': 'Pull-Apply ohne user — required ist der einzige Schutz',
+  customers: 'Pull-Apply ohne user — required ist der einzige Schutz',
+  'corporate-customers': 'Pull-Apply ohne user — required ist der einzige Schutz',
+  'opening-hour-exceptions': 'Pull-Apply ohne user — required ist der einzige Schutz',
+  discounts: 'Pull-Apply ohne user — required ist der einzige Schutz',
+}
+
 export type StampFieldViolation = {
   path: string
   /** Feld fehlt im geschlossenen Schema → jeder externe Create scheitert. */
@@ -188,7 +223,9 @@ export function assertStampFields(app: AppLike): StampFieldViolation[] {
   }
 
   // Aggregiert: eine Zeile fuer alle Services, sonst ertraenkt der Befund das Boot-Log.
-  const requiredOnly = violations.filter(v => !v.missing.length && v.required.length)
+  const requiredOnly = violations.filter(
+    v => !v.missing.length && v.required.length && !REQUIRED_STAMP_EXCEPTIONS[v.path],
+  )
   if (requiredOnly.length) {
     logger.warn({
       message:

--- a/libs/domains/apikeys/domain/src/lib/apikey.schema.ts
+++ b/libs/domains/apikeys/domain/src/lib/apikey.schema.ts
@@ -35,10 +35,18 @@ export type Apikey = Static<typeof apikeySchema>
 //#endregion
 
 //#region Schema für das Erstellen (POST)
-// Wir picken nur die Felder, die der Client senden darf
+// Wir picken nur die Felder, die der Client senden darf.
+//
+// `tenantId`/`locationId` sind bewusst OPTIONAL: beide werden serverseitig von
+// `multiTenancy()` gestempelt, kein Client sendet sie. Als Pflichtfelder
+// koppelten sie die Fehlermeldung an den Stempel-Erfolg — greift der Stempel
+// nicht, meldet die API „must have required property 'locationId'" und zeigt
+// damit auf den Client, obwohl die Ursache serverseitig liegt. Genau so ist der
+// Bug vom 2026-08-01 aufgeschlagen (ADR 0031 in panary-cloud).
 export const apikeyDataSchema = Type.Intersect(
   [
-    Type.Pick(apikeySchema, ['description', 'deviceId', 'locationId', 'name', 'tenantId', 'validUntil']),
+    Type.Pick(apikeySchema, ['description', 'deviceId', 'name', 'validUntil']),
+    Type.Partial(Type.Pick(apikeySchema, ['locationId', 'tenantId'])),
     Type.Object({
       role: Type.Optional(StringEnum(Object.values(UserSystemRole))),
     }),

--- a/libs/domains/devices/domain/src/lib/device.schema.ts
+++ b/libs/domains/devices/domain/src/lib/device.schema.ts
@@ -83,8 +83,11 @@ export const deviceDataSchema = Type.Object(
   {
     name: Type.String({ maxLength: 100 }),
     type: StringEnum(Object.values(DeviceType)),
-    locationId: Type.String(),
-    tenantId: Type.String(),
+    // Optional, weil serverseitig von `multiTenancy()` gestempelt — als
+    // Pflichtfeld waere die 400-Meldung bei fehlgeschlagenem Stempel
+    // irrefuehrend (ADR 0031 in panary-cloud).
+    locationId: Type.Optional(Type.String()),
+    tenantId: Type.Optional(Type.String()),
     metadata: Type.Optional(
       Type.Object({
         userAgent: Type.Optional(Type.String({ maxLength: 512 })),

--- a/libs/domains/order-interactions/domain/src/lib/order-interaction.schema.ts
+++ b/libs/domains/order-interactions/domain/src/lib/order-interaction.schema.ts
@@ -118,8 +118,6 @@ export type OrderInteraction = Static<typeof orderInteractionSchema>
 const orderInteractionPickedDataSchema = Type.Pick(
   orderInteractionSchema,
   [
-    'tenantId',
-    'locationId',
     'type',
     'orderId',
     'userId',
@@ -174,6 +172,10 @@ const orderInteractionPickedDataSchema = Type.Pick(
 export const orderInteractionDataSchema = Type.Intersect(
   [
     Type.Object({ _id: Type.Optional(Type.String()) }),
+    // `tenantId`/`locationId` optional: serverseitig von `multiTenancy()`
+    // gestempelt. Als Pflichtfelder waere die 400-Meldung bei fehlgeschlagenem
+    // Stempel irrefuehrend (ADR 0031 in panary-cloud).
+    Type.Partial(Type.Pick(orderInteractionSchema, ['tenantId', 'locationId'])),
     orderInteractionPickedDataSchema,
   ],
   {

--- a/libs/domains/orders/domain/src/lib/order.schema.ts
+++ b/libs/domains/orders/domain/src/lib/order.schema.ts
@@ -407,11 +407,13 @@ export type OrderTse = Static<typeof orderTseSchema>
 export const orderDataSchema = Type.Intersect(
   [
     Type.Object({ _id: Type.Optional(Type.String()) }),
+    // `tenantId`/`locationId` optional: serverseitig von `multiTenancy()`
+    // gestempelt. Als Pflichtfelder waere die 400-Meldung bei fehlgeschlagenem
+    // Stempel irrefuehrend (ADR 0031 in panary-cloud).
+    Type.Partial(Type.Pick(orderSchema, ['locationId', 'tenantId'])),
     Type.Pick(
       orderSchema,
       [
-        'locationId',
-        'tenantId',
         'createdAt',
         'updatedAt',
         'status',

--- a/libs/domains/receipts/domain/src/lib/receipt.schema.ts
+++ b/libs/domains/receipts/domain/src/lib/receipt.schema.ts
@@ -193,9 +193,11 @@ export type Receipt = Static<typeof receiptSchema>
 export const receiptDataSchema = Type.Intersect(
   [
     Type.Object({ _id: Type.Optional(Type.String({ format: 'uuid' })) }),
+    // `tenantId`/`locationId` optional: serverseitig von `multiTenancy()`
+    // gestempelt. Als Pflichtfelder waere die 400-Meldung bei fehlgeschlagenem
+    // Stempel irrefuehrend (ADR 0031 in panary-cloud).
+    Type.Partial(Type.Pick(receiptSchema, ['tenantId', 'locationId'])),
     Type.Pick(receiptSchema, [
-      'tenantId',
-      'locationId',
       'createdAt',
       'updatedAt',
       'kind',

--- a/libs/domains/user-preferences/domain/src/lib/user-preference.schema.ts
+++ b/libs/domains/user-preferences/domain/src/lib/user-preference.schema.ts
@@ -16,9 +16,14 @@ export type UserPreference = Static<typeof userPreferenceSchema>
 //#endregion
 
 //#region Schema for creation (POST)
-export const userPreferenceDataSchema = Type.Pick(
-  userPreferenceSchema,
-  ['tenantId', 'locationId', 'key', 'value', 'userId'],
+// `tenantId`/`locationId` optional: serverseitig von `multiTenancy()` gestempelt,
+// kein Client sendet sie. Als Pflichtfelder waere die 400-Meldung bei
+// fehlgeschlagenem Stempel irrefuehrend (ADR 0031 in panary-cloud).
+export const userPreferenceDataSchema = Type.Intersect(
+  [
+    Type.Pick(userPreferenceSchema, ['key', 'value', 'userId']),
+    Type.Partial(Type.Pick(userPreferenceSchema, ['tenantId', 'locationId'])),
+  ],
   {
     $id: 'UserPreferenceData',
     additionalProperties: false,


### PR DESCRIPTION
Folgearbeit zu #78. Schliesst die dort im Boot-Log sichtbar gemachte Schema-Falle — aber nur dort, wo sie nachweislich ohne Nebenwirkung zu schliessen ist.

## Problem

`tenantId`/`locationId` werden von `multiTenancy()` serverseitig gestempelt; kein Client sendet sie (die Frontend-Typen strippen sie sogar aktiv, z. B. `Omit<Order,'_id'|'locationId'|'tenantId'>`). Als **Pflichtfelder** im DATA-Schema koppeln sie die Fehlermeldung an den Stempel-Erfolg: greift der Stempel nicht, meldet die API `must have required property 'locationId'` und zeigt damit auf den Client, obwohl die Ursache serverseitig liegt. Genau so ist der apikeys-400 vom 2026-08-01 aufgeschlagen.

## Gelockert (6 Services)

`apikeys`, `devices`, `user-preferences`, `receipts`, `order-interactions`, `orders` — kein Sync-Pull-Apply-Ziel, kein DB-NOT-NULL, interne Caller (`device-pairing`, `devices`, `issue-receipt.hook`, `pre-orders`) setzen die Felder explizit.

Wichtig: optional heisst **nicht** entfernt. Die Felder bleiben deklariert, sonst lehnte AJV den gestempelten Wert als `additionalProperty` ab (`additionalProperties: false`) — die andere Haelfte derselben Falle. Ein Test haelt das fest.

## Bewusst NICHT gelockert (8 Services)

Das ist der interessantere Teil des PRs, und der Grund, warum das hier kein Blanket-Refactor ist:

- **`pre-orders`, `locations`** — SQLite hat dort `notNullable` (`20260328000004`, `20260219000002`). Optional zu machen verwandelt einen klaren 400 in einen `NOT NULL constraint failed`-500. Verschlechterung.
- **`products`, `product-groups`, `customers`, `corporate-customers`, `opening-hour-exceptions`, `discounts`** — Ziel des Cloud→Edge-Pull-Apply (`sync-apply.ts`, `create(..., { provider: undefined, fromSync: true })`), der **ohne `user`** laeuft und deshalb nicht gestempelt wird. `required` ist dort die einzige Instanz, die einen defekten Cloud-Record laut ablehnt (REJECTED im `sync-runs`-Detail). Ohne sie landete er still mit `NULL` in der Edge-DB und waere fuer den filial-gescopten POS unsichtbar — „gesynct, aber nicht da", ohne jede Fehlermeldung. Das ist schlechter als der irrefuehrende 400.

Fuer 11 der 14 Services gibt es hinter dem Data-Schema **gar nichts mehr**: kein Resolver setzt die Felder, und die Knex-Spalten sind ueberwiegend `nullable`. Blanket-Lockerung waere hier ein echtes Loch gewesen.

## Boot-Check

Die acht Ausnahmen stehen jetzt als `REQUIRED_STAMP_EXCEPTIONS` im Check, **jede mit ihrer Begruendung**, und erzeugen keine Warnung mehr. Dieselbe Zeile bei jedem Boot waere nach drei Wochen unsichtbar; die Warnung soll fuer neue, unbeabsichtigte Faelle scharf bleiben. Das Boot-Log ist damit still — vorher meldete es 14 Services.

## Verifikation

`nx test`: 555 passed (470 api-edge, 85 shared-backend). `nx build` fuer api-edge, pos-client, admin-client, setup-client sauber — relevant, weil die Typen jetzt optional sind und Konsumenten das sehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)