### PR TITLE
fix(orders): Dot-Query-Felder auch innerhalb von $or zulassen

### DIFF
--- a/libs/domains/orders/domain/src/lib/order.schema.spec.ts
+++ b/libs/domains/orders/domain/src/lib/order.schema.spec.ts
@@ -194,3 +194,29 @@ describe('orderQuerySchema — Betragssuche', () => {
     expect(Value.Check(orderQuerySchema, { 'taxSnapshot.brutto': { $regex: '6' } })).toBe(false)
   })
 })
+
+// Regression zu 26.8.2: die Dot-Felder hingen nur am ERGEBNIS von `querySyntax`.
+// Der `$or`-Zweig wird aber aus dessen EINGABE gebaut und traegt
+// `additionalProperties: false` — er kannte die Felder daher nicht und wies die
+// Suche der Bestellliste mit „BadRequest: validation failed" ab. Die Tests oben
+// liefen trotzdem gruen, weil sie ausschliesslich die oberste Ebene pruefen.
+describe('orderQuerySchema — Dot-Felder innerhalb von $or', () => {
+  it('akzeptiert die Betragssuche der Bestellliste', () => {
+    expect(Value.Check(orderQuerySchema, { $or: [{ 'taxSnapshot.brutto': { $gte: 5.685, $lte: 5.695 } }] })).toBe(true)
+  })
+
+  it('akzeptiert Nummer und Betrag nebeneinander (rein numerische Eingabe)', () => {
+    const query = {
+      $or: [{ dailySequenceNumber: 1040 }, { 'taxSnapshot.brutto': { $gte: 1039.995, $lte: 1040.005 } }],
+    }
+    expect(Value.Check(orderQuerySchema, query)).toBe(true)
+  })
+
+  it('akzeptiert $exists auf einem Dot-Feld innerhalb von $or', () => {
+    expect(Value.Check(orderQuerySchema, { $or: [{ 'staffPaymentInfo.userId': { $exists: true } }] })).toBe(true)
+  })
+
+  it('lehnt ein unbekanntes Feld innerhalb von $or weiterhin ab', () => {
+    expect(Value.Check(orderQuerySchema, { $or: [{ nichtVorhanden: 'x' }] })).toBe(false)
+  })
+})

--- a/libs/domains/orders/domain/src/lib/order.schema.ts
+++ b/libs/domains/orders/domain/src/lib/order.schema.ts
@@ -489,44 +489,39 @@ export const orderQueryProperties = Type.Pick(orderSchema, [
   // Flattened or specific properties could be added if needed
 ])
 // Dot-Notation-Filter fuer verschachtelte Felder (Admin-Bestellliste: „nur
-// Personalessen", „nur rabattierte", „Rabatt X").
+// Personalessen", „nur rabattierte", „Rabatt X", Suche nach dem Betrag).
 //
 // BEWUSST flach und explizit statt `staffPaymentInfo`/`appliedDiscounts` in
 // `orderQueryProperties` zu picken: `querySyntax` ueber verschachtelte Objekt-
 // bzw. Array-Typen treibt die Typtiefe hoch und laeuft in TS2589
-// („type instantiation is excessively deep") — dieselbe Falle, die weiter unten
-// schon das `$or` aus dem Intersect ins Flat-Object gezwungen hat.
+// („type instantiation is excessively deep").
 //
-// Erlaubt ist je Feld ein Gleichheits-Match (konkreter Mitarbeiter / Rabatt) oder
-// ein `$exists` (ueberhaupt Personalessen / ueberhaupt rabattiert).
-const existsOrEquals = Type.Optional(
-  Type.Union([Type.String(), Type.Object({ $exists: Type.Boolean() }, { additionalProperties: false })]),
-)
+// Die Felder laufen DURCH `querySyntax` und stehen damit auch innerhalb von
+// `$or`/`$and` zur Verfuegung. Sie nur nachtraeglich an dessen Ergebnis zu haengen
+// (so bis 26.8.2) reichte nicht: der `$or`-Zweig wird aus den uebergebenen
+// Properties gebaut und traegt `additionalProperties: false`. Die Betragssuche der
+// Bestellliste sendet `{ $or: [{ 'taxSnapshot.brutto': … }] }` und lief deshalb in
+// „BadRequest: validation failed", waehrend der Art-Filter funktionierte — der
+// setzt seine Bedingung auf oberster Ebene.
+const orderQueryPropertiesWithNested = Type.Object({
+  ...orderQueryProperties.properties,
+  'staffPaymentInfo.userId': Type.String(),
+  'appliedDiscounts.discountId': Type.String(),
+  // Betragssuche: der Aufrufer fragt eine schmale Spanne statt Gleichheit ab —
+  // `taxSnapshot.brutto` ist ein Double, und ein exakter Vergleich auf einen aus
+  // Nutzereingabe geparsten Wert (`'6,70'` → `6.7`) ist bei Fliesskomma
+  // unzuverlaessig. Die Range-Operatoren (`$gte`/`$lte`) liefert `querySyntax` mit.
+  'taxSnapshot.brutto': Type.Number(),
+})
 
-// Betragssuche der Admin-Bestellliste. Bewusst als RANGE statt Gleichheit:
-// `taxSnapshot.brutto` ist ein Double, und ein exakter Vergleich auf einen aus
-// Nutzereingabe geparsten Wert (`'6,70'` → `6.7`) ist bei Fliesskomma
-// unzuverlaessig. Der Aufrufer sucht deshalb mit einer schmalen Spanne um den
-// eingegebenen Betrag.
-const numericRange = Type.Optional(
-  Type.Union([
-    Type.Number(),
-    Type.Object(
-      { $gte: Type.Optional(Type.Number()), $lte: Type.Optional(Type.Number()) },
-      { additionalProperties: false },
-    ),
-  ]),
-)
-
-const _orderQueryBase = querySyntax(orderQueryProperties)
-export const orderQuerySchema = Type.Object(
-  {
-    ..._orderQueryBase.properties,
-    'staffPaymentInfo.userId': existsOrEquals,
-    'appliedDiscounts.discountId': existsOrEquals,
-    'taxSnapshot.brutto': numericRange,
-  },
-  { additionalProperties: false },
-)
+// `$exists` gehoert nicht zum Standard-Operatorsatz von `querySyntax`, wird fuer
+// „ueberhaupt Personalessen" / „ueberhaupt rabattiert" aber gebraucht. Ueber den
+// extensions-Parameter gilt es an jeder Stelle, an der die Property vorkommt —
+// oberste Ebene wie `$or`.
+const _orderQueryBase = querySyntax(orderQueryPropertiesWithNested, {
+  'staffPaymentInfo.userId': { $exists: Type.Boolean() },
+  'appliedDiscounts.discountId': { $exists: Type.Boolean() },
+})
+export const orderQuerySchema = Type.Object(_orderQueryBase.properties, { additionalProperties: false })
 export type OrderQuery = Static<typeof orderQuerySchema>
 //#endregion


### PR DESCRIPTION
## Problem

Die Betragssuche der Admin-Bestellliste lief seit `26.7.42` in
`BadRequest: validation failed` und filterte nicht — am 2026-08-03 auf Staging
verifiziert (Eingabe `5,69` → Liste bleibt ungefiltert, Konsole meldet den 400).

Ursache: `staffPaymentInfo.userId`, `appliedDiscounts.discountId` und
`taxSnapshot.brutto` hingen nur am **Ergebnis** von `querySyntax`. Der `$or`-Zweig
wird aber aus dessen **Eingabe** gebaut und trägt `additionalProperties: false` —
er kannte die Felder daher nicht.

Gemessen gegen `@panary/orders` 26.8.3:

```
Top-Level kennt taxSnapshot.brutto : true
$or kennt taxSnapshot.brutto       : false
$or kennt dailySequenceNumber      : true
```

Deshalb funktionierte der **Art-Filter** (setzt seine Bedingung auf oberster Ebene),
die **Suche** aber nicht — sie sendet `{ $or: [{ 'taxSnapshot.brutto': … }] }`.

## Lösung

Die drei Felder laufen jetzt durch `querySyntax` und stehen damit auf beiden Ebenen
zur Verfügung. `$exists` kommt über den `extensions`-Parameter dazu, weil es nicht
zum Standard-Operatorsatz gehört.

Unverändert bleiben: Semantik je Feld (Gleichheit oder `$exists`, Range auf dem
Betrag) und `additionalProperties: false` auf beiden Ebenen.

## Verifiziert

- `nx test orders-domain`: **143 Tests grün** (vorher 139)
- Vier neue Regressionstests decken den `$or`-Fall ab — die bestehenden prüfen
  ausschließlich die oberste Ebene und liefen deshalb grün, während die Suche brach
- Am **gebauten** Artefakt geprüft: alle drei Felder in `$or` und Top-Level,
  `additionalProperties: false` erhalten, `$exists` im `$or` verfügbar
- `nx build api-edge` erfolgreich
- Schema wächst um ~21 % (mehr Operatoren pro Feld) — ohne Laufzeitwirkung, AJV
  kompiliert einmal beim Boot

## Nach dem Merge

Release `v26.8.4` + Pin-Bump in panary-cloud, sonst greift der Fix dort nicht
(Registry-Autarkie). Hinweis: `26.8.3` ist bereits publiziert, ohne dass ein
git-Tag existiert — root/api-edge/tauri stehen noch auf `26.8.2`.
