### PR TITLE
feat(businessdays): openedAt als Query-Property zulassen

### DIFF
--- a/libs/domains/businessdays/domain/src/lib/business-day.schema.ts
+++ b/libs/domains/businessdays/domain/src/lib/business-day.schema.ts
@@ -103,6 +103,10 @@ export const businessDayQueryProperties = Type.Pick(businessDaySchema, [
   'isOpen',
   'operationMode',
   'reportId',
+  // Flaches date-time-Feld, deshalb ueber Type.Pick sicher: querySyntax baut das
+  // volle Operator-Set ($gt/$lt/…) daraus. Verschachtelte Felder gehoeren hier
+  // NICHT hinein (querySyntax ueber Objekt-/Array-Typen laeuft in TS2589).
+  'openedAt',
 ])
 const _businessDayQueryBase = querySyntax(businessDayQueryProperties)
 export const businessDayQuerySchema = Type.Object(


### PR DESCRIPTION
## Kontext

Vorgemerkte Kleinigkeit, die für sich kein Release rechtfertigt (Release + Pin-Bump + Merge ≈ 30 Min) und deshalb beim nächsten ohnehin anstehenden Core-Release mitfahren soll — hier: dem Release, das auch #98/#99/#100 transportiert.

## Änderung

`'openedAt'` in den `Type.Pick` der `businessDayQueryProperties`.

Das Feld ist ein **flaches** `date-time`-Feld und geht deshalb sauber über `Type.Pick` → `querySyntax`, das daraus das volle Operator-Set (`$gt`/`$lt`/…) baut. Damit greift keine der beiden bekannten Fallen:

- **TS2589** entsteht nur bei `querySyntax` über Objekt-/Array-Typen — hier nicht der Fall.
- **Die `$or`-Falle**, an der die Betragssuche zwei Releases lang hing, entsteht nur, wenn man Dot-Properties *nachträglich* an das Ergebnis von `querySyntax` hängt: Der `$or`-Zweig wird aus der Eingabe gebaut und trägt `additionalProperties: false`, kennt nachträglich ergänzte Felder also nicht. Hier läuft das Feld durch `querySyntax` hindurch.

## Verifikation

`nx lint` + `nx build` für `businessdays-domain` grün (kein TS2589).

Verhaltensnachweis mit Ajv gegen das **gebaute** Schema (`businessdays-domain/dist`) — die Lib hat kein Test-Target, deshalb direkt am Artefakt statt über neu aufgebaute Test-Infrastruktur:

```
OK  openedAt exakt                     → akzeptiert
OK  openedAt Range ($gte/$lt)          → akzeptiert
OK  openedAt in $or                    → akzeptiert
OK  status (Kontrolle, unverändert)    → akzeptiert
OK  unbekanntes Feld                   → weiterhin abgelehnt
```

Der letzte Fall belegt, dass `additionalProperties: false` intakt bleibt.

## Hinweis

Gehört zusammen mit #100 in denselben `v*`-Tag. Ein Core-Tag rollt binnen ~1 h auf die gesamte Flotte (core hat keinen Staging-Kanal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)