### PR TITLE
AppResource FISCAL_DEVICES + NotificationEventType für die Meldefrist (§ 146a Abs. 4 AO)

### DIFF
--- a/libs/domains/notifications/domain/src/lib/notification-event.spec.ts
+++ b/libs/domains/notifications/domain/src/lib/notification-event.spec.ts
@@ -1,0 +1,49 @@
+import { NOTIFICATION_EVENT_META, NotificationCategory, NotificationEventType } from './notification-event'
+
+/**
+ * `NOTIFICATION_EVENT_META` ist als `Record<NotificationEventType, …>` typisiert
+ * — ein fehlender Eintrag ist damit schon ein Compile-Fehler. Der Test haelt
+ * die Invariante trotzdem zur Laufzeit fest: Wird der Record-Typ spaeter
+ * gelockert (`Partial<…>`, Index-Signatur), faellt es hier auf statt erst beim
+ * Nutzer, dessen Benachrichtigung ohne Label und ohne Default-Channels
+ * ankommt.
+ */
+describe('NOTIFICATION_EVENT_META', () => {
+  it('kennt jeden Event-Typ', () => {
+    for (const eventType of Object.values(NotificationEventType)) {
+      expect(NOTIFICATION_EVENT_META[eventType], eventType).toBeDefined()
+    }
+  })
+
+  it('gibt jedem Event ein Label und eine Kategorie', () => {
+    for (const [eventType, meta] of Object.entries(NOTIFICATION_EVENT_META)) {
+      expect(meta.label.length, eventType).toBeGreaterThan(0)
+      expect(Object.values(NotificationCategory), eventType).toContain(meta.category)
+    }
+  })
+
+  it('haelt In-App fuer jeden Event an — es ist der Fallback-Kanal', () => {
+    // E-Mail und Push koennen fehlschlagen oder abbestellt sein; die In-App-Row
+    // ist die einzige Zustellung, die immer ankommt.
+    for (const [eventType, meta] of Object.entries(NOTIFICATION_EVENT_META)) {
+      expect(meta.defaults.inApp, eventType).toBe(true)
+    }
+  })
+})
+
+describe('FISCAL_REPORTING_DUE', () => {
+  it('liegt in der Fiskal-Kategorie, nicht bei Billing', () => {
+    // Es geht um eine steuerliche Pflicht des Betriebs, nicht um sein Abo.
+    expect(NOTIFICATION_EVENT_META[NotificationEventType.FISCAL_REPORTING_DUE].category).toBe(
+      NotificationCategory.CLOSING,
+    )
+  })
+
+  it('ist auf allen Kanaelen vorbelegt — gesetzliche Frist', () => {
+    expect(NOTIFICATION_EVENT_META[NotificationEventType.FISCAL_REPORTING_DUE].defaults).toEqual({
+      inApp: true,
+      email: true,
+      push: true,
+    })
+  })
+})

--- a/libs/domains/notifications/domain/src/lib/notification-event.ts
+++ b/libs/domains/notifications/domain/src/lib/notification-event.ts
@@ -66,6 +66,23 @@ export const NotificationEventType = {
    * kein Spam-Risiko.
    */
   SUBSCRIPTION_TRIAL_WILL_END: 'subscription.trial_will_end',
+
+  /**
+   * Kassenmeldung nach § 146a Abs. 4 AO ist fällig: Ein Standort wurde in den
+   * fiskalischen Kassenbetrieb geschaltet. Die Mitteilung an das Finanzamt hat
+   * **innerhalb eines Monats** zu erfolgen (elektronisch über Mein ELSTER bzw.
+   * ERiC). Adressat: TENANT_OWNER.
+   *
+   * Alle Channels default an — analog SUBSCRIPTION_TRIAL_WILL_END: seltenes
+   * Ereignis mit gesetzlicher Frist, kein Spam-Risiko.
+   *
+   * Wichtig für den Auslöser: Die Benachrichtigung ist eine **Erinnerung, kein
+   * Erfüllungsnachweis**. Die Pflicht besteht bis zur Meldung fort; der
+   * dauerhafte Zustand lebt in der Checkliste unter `/settings/kassenmeldung`
+   * (panary-cloud docs/domains/kassenmeldung-146a.md). Diesen Event NICHT als
+   * „erledigt"-Marker verwenden.
+   */
+  FISCAL_REPORTING_DUE: 'fiscal.reporting_due',
 } as const
 
 export type NotificationEventType = (typeof NotificationEventType)[keyof typeof NotificationEventType]
@@ -204,6 +221,14 @@ export const NOTIFICATION_EVENT_META: Record<NotificationEventType, Notification
     // Erinnerung nicht verpassen (E-Mail + Push), sonst läuft der Zugang aus.
     category: NotificationCategory.BILLING,
     label: 'Testphase endet bald',
+    defaults: { inApp: true, email: true, push: true },
+  },
+  [NotificationEventType.FISCAL_REPORTING_DUE]: {
+    // Gesetzliche Monatsfrist: alle Channels default an, analog Trial-Ende.
+    // Kategorie CLOSING (Tagesabschluss/Fiskal), nicht BILLING — es geht um
+    // eine steuerliche Pflicht des Betriebs, nicht um sein Abo bei uns.
+    category: NotificationCategory.CLOSING,
+    label: 'Kassenmeldung ans Finanzamt fällig',
     defaults: { inApp: true, email: true, push: true },
   },
 }

--- a/libs/domains/users/domain/src/lib/permissions.ts
+++ b/libs/domains/users/domain/src/lib/permissions.ts
@@ -193,6 +193,24 @@ export const AppResource = {
    *  (Socket-Registry). Read-only `find` → { online, total, connectedDeviceIds }.
    *  READ für TENANT_OWNER + TENANT_TECHNICIAN (spiegelt die DEVICES-Leserechte). */
   DEVICE_CONNECTIONS: 'device-connections',
+  /** Cloud-only: Register der meldepflichtigen Aufzeichnungssysteme je
+   *  Betriebsstätte für die Kassenmeldung nach § 146a Abs. 4 AO.
+   *
+   *  Bewusst NICHT `DEVICES`: dort stehen die von Panary verwalteten Geräte.
+   *  Dieses Register führt die **Meldesicht** — inklusive Kassen anderer
+   *  Hersteller, die Panary nie sieht. Die Meldung folgt der Bruttomethode
+   *  (bei jeder Meldung alle eAS der Betriebsstätte), eine Liste nur der
+   *  eigenen Geräte wäre systematisch unvollständig und damit objektiv
+   *  unrichtig.
+   *
+   *  Inhalt sind Steuer- und Gerätestammdaten (Steuernummer, TSE-Seriennummer,
+   *  BSI-Zertifizierungs-ID, Anschaffungsdaten). TENANT_OWNER/TECHNICIAN:
+   *  MANAGE. TENANT_MANAGER: READ+CREATE+UPDATE (pflegt, löscht nicht —
+   *  ein außer Betrieb genommenes Gerät wird abgemeldet, nicht entfernt).
+   *  TENANT_STAFF: KEIN Eintrag — kein betrieblicher Anlass, und der Datensatz
+   *  trägt die Steuernummer des Betriebs.
+   *  Siehe panary-cloud docs/domains/kassenmeldung-146a.md. */
+  FISCAL_DEVICES: 'fiscal-devices',
   SHIFTS: 'shifts',
   SHIFT_TEMPLATES: 'shift-templates',
   SHIFT_SWAP_REQUESTS: 'shift-swap-requests',

--- a/libs/domains/users/domain/src/lib/roles.matrix.spec.ts
+++ b/libs/domains/users/domain/src/lib/roles.matrix.spec.ts
@@ -212,3 +212,43 @@ describe('RolePermissions — MEAL_SETTLEMENTS (Sammelabrechnung offener Persona
     }
   })
 })
+
+/**
+ * Melderegister fuer die Kassenmeldung nach § 146a Abs. 4 AO.
+ *
+ * Das Register fuehrt die MELDESICHT — inklusive Kassen anderer Hersteller,
+ * die Panary nie sieht (Bruttomethode). Es traegt Steuer- und
+ * Geraetestammdaten, deshalb ist der Zugriff enger als bei `DEVICES`.
+ */
+describe('RolePermissions — FISCAL_DEVICES (§ 146a Abs. 4 AO)', () => {
+  it('TENANT_OWNER darf voll verwalten — er verantwortet die Meldung', () => {
+    expect(roleActions(UserSystemRole.TENANT_OWNER, AppResource.FISCAL_DEVICES).sort()).toEqual(
+      [AppAction.CREATE, AppAction.DELETE, AppAction.READ, AppAction.UPDATE].sort(),
+    )
+  })
+
+  it('TENANT_TECHNICIAN darf voll verwalten — er kennt Serien- und TSE-Nummern', () => {
+    expect(roleCan(UserSystemRole.TENANT_TECHNICIAN, AppResource.FISCAL_DEVICES, AppAction.UPDATE)).toBe(true)
+    expect(roleCan(UserSystemRole.TENANT_TECHNICIAN, AppResource.FISCAL_DEVICES, AppAction.DELETE)).toBe(true)
+  })
+
+  it('TENANT_MANAGER darf pflegen, aber NICHT loeschen', () => {
+    // Ein ausser Betrieb genommenes Geraet wird abgemeldet, nicht entfernt —
+    // die Meldehistorie muss nachvollziehbar bleiben.
+    expect(roleActions(UserSystemRole.TENANT_MANAGER, AppResource.FISCAL_DEVICES).sort()).toEqual(
+      [AppAction.CREATE, AppAction.READ, AppAction.UPDATE].sort(),
+    )
+    expect(roleCan(UserSystemRole.TENANT_MANAGER, AppResource.FISCAL_DEVICES, AppAction.DELETE)).toBe(false)
+  })
+
+  it('TENANT_STAFF hat keinerlei Zugriff', () => {
+    // Kein betrieblicher Anlass, und der Datensatz traegt die Steuernummer.
+    expect(roleActions(UserSystemRole.TENANT_STAFF, AppResource.FISCAL_DEVICES)).toEqual([])
+  })
+
+  it('Geraete-Rollen haben keinerlei Zugriff', () => {
+    for (const role of [UserSystemRole.DEVICE_POS, UserSystemRole.DEVICE_KDS, UserSystemRole.DEVICE_TABLET]) {
+      expect(roleActions(role, AppResource.FISCAL_DEVICES)).toEqual([])
+    }
+  })
+})

--- a/libs/domains/users/domain/src/lib/roles.matrix.ts
+++ b/libs/domains/users/domain/src/lib/roles.matrix.ts
@@ -341,6 +341,9 @@ export const RolePermissions: Record<UserSystemRole, PermissionRule[]> = {
     { resource: AppResource.DEVICES, action: AppAction.MANAGE },
     // Live-Verbindungszählung der Geräte (Socket-Registry) — read-only.
     { resource: AppResource.DEVICE_CONNECTIONS, action: AppAction.READ },
+    // Melderegister § 146a Abs. 4 AO: der Owner verantwortet die Meldung
+    // gegenueber dem Finanzamt und darf das Register voll verwalten.
+    { resource: AppResource.FISCAL_DEVICES, action: AppAction.MANAGE },
     { resource: AppResource.SHIFTS, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_TEMPLATES, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_SWAP_REQUESTS, action: AppAction.MANAGE },
@@ -547,6 +550,9 @@ export const RolePermissions: Record<UserSystemRole, PermissionRule[]> = {
     { resource: AppResource.DEVICES, action: AppAction.MANAGE },
     // Live-Verbindungszählung der Geräte (Socket-Registry) — read-only.
     { resource: AppResource.DEVICE_CONNECTIONS, action: AppAction.READ },
+    // Melderegister § 146a Abs. 4 AO: der Techniker installiert die Geraete und
+    // kennt Serien- und TSE-Nummern — er traegt die Meldedaten ein.
+    { resource: AppResource.FISCAL_DEVICES, action: AppAction.MANAGE },
     { resource: AppResource.SHIFTS, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_TEMPLATES, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_SWAP_REQUESTS, action: AppAction.MANAGE },
@@ -686,6 +692,10 @@ export const RolePermissions: Record<UserSystemRole, PermissionRule[]> = {
     // Sammelabrechnung: der Filialleiter ist der eigentliche Nutzer.
     { resource: AppResource.MEAL_SETTLEMENTS, action: [AppAction.READ, AppAction.CREATE] },
     { resource: AppResource.USER_PREFERENCES, action: AppAction.MANAGE },
+    // Melderegister § 146a Abs. 4 AO: pflegen ja, loeschen nein. Ein ausser
+    // Betrieb genommenes Geraet wird abgemeldet (Feld `decommissionedAt`),
+    // nicht entfernt — die Meldehistorie muss nachvollziehbar bleiben.
+    { resource: AppResource.FISCAL_DEVICES, action: [AppAction.READ, AppAction.CREATE, AppAction.UPDATE] },
     { resource: AppResource.SHIFTS, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_TEMPLATES, action: AppAction.MANAGE },
     { resource: AppResource.SHIFT_SWAP_REQUESTS, action: AppAction.MANAGE },


### PR DESCRIPTION
Legt die beiden Core-Bausteine an, die panary-cloud für die Kassenmeldung nach § 146a Abs. 4 AO braucht und die dort konstruktionsbedingt nicht entstehen können: ein neuer Service braucht `AppResource` + Matrix-Regeln (sonst 403 für alle Tenant-User), und `NotificationEventType` ist ein harter Enum, gegen den das Notification-Schema validiert.

Beides ist **rein additiv** — keine bestehende Regel und kein bestehender Event ändert sich.

## `AppResource.FISCAL_DEVICES`

Register der meldepflichtigen Aufzeichnungssysteme je Betriebsstätte.

Bewusst **nicht** `DEVICES`: dort stehen die von Panary verwalteten Geräte. Dieses Register führt die **Meldesicht** — inklusive Kassen anderer Hersteller, die Panary nie sieht. Die Meldung folgt der Bruttomethode (bei jeder Meldung *alle* eAS der Betriebsstätte); eine Liste nur der eigenen Geräte wäre systematisch unvollständig und damit objektiv unrichtig.

| Rolle | Rechte | Begründung |
|---|---|---|
| `TENANT_OWNER` | MANAGE | verantwortet die Meldung gegenüber dem Finanzamt |
| `TENANT_TECHNICIAN` | MANAGE | installiert die Geräte, kennt Serien- und TSE-Nummern |
| `TENANT_MANAGER` | READ + CREATE + UPDATE | pflegt, **löscht nicht** — ein außer Betrieb genommenes Gerät wird abgemeldet, nicht entfernt; die Meldehistorie muss nachvollziehbar bleiben |
| `TENANT_STAFF` | *kein Eintrag* | kein betrieblicher Anlass, und der Datensatz trägt die Steuernummer des Betriebs |

## `NotificationEventType.FISCAL_REPORTING_DUE`

Erinnerung an die Monatsfrist beim Wechsel in den fiskalischen Kassenbetrieb.

Kategorie **CLOSING** (Fiskal), nicht BILLING: es geht um eine steuerliche Pflicht des Betriebs, nicht um sein Abo bei uns. Alle Kanäle default an, analog `SUBSCRIPTION_TRIAL_WILL_END` — seltenes Ereignis mit gesetzlicher Frist, kein Spam-Risiko.

Im Enum-Kommentar festgehalten, weil es der Auslöser leicht falsch macht: **Der Event ist eine Erinnerung, kein Erfüllungsnachweis.** Die Pflicht besteht bis zur Meldung fort; der dauerhafte Zustand lebt in der Checkliste unter `/settings/kassenmeldung`. Nicht als „erledigt"-Marker verwenden.

## Verifikation

- `users-domain` 135 Tests grün (5 neue Matrix-Tests, u. a. dass MANAGER kein DELETE bekommt und STAFF gar nichts)
- `notifications-domain` 5 neue Tests — Vollständigkeit von `NOTIFICATION_EVENT_META` zur Laufzeit (der `Record`-Typ erzwingt es heute beim Compile; der Test hält es fest, falls der Typ je gelockert wird) plus die Invariante, dass In-App bei jedem Event an ist
- alle 39 publishable Libs bauen, `nx affected -t test` über 13 Projekte grün, `format:check` sauber

## Konsument

panary-cloud, Welle 5 Stufe B (Fremdgeräte-Register + Assistent) — siehe dort `docs/domains/kassenmeldung-146a.md` und ADR 0037. Der XML-Assistent bleibt zusätzlich bis zur ERiC-Herstellerregistrierung blockiert (das amtliche `Aufzeichnung146a`-Schema ist nicht öffentlich).

🤖 Generated with [Claude Code](https://claude.com/claude-code)