### PR TITLE
fix(build): nx typecheck lief workspace-weit ins Leere

### DIFF
--- a/apps/admin-client/tsconfig.app.json
+++ b/apps/admin-client/tsconfig.app.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // Siehe tsconfig.spec.json: `tsc --build --emitDeclarationOnly` laeuft ueber
+    // alle referenzierten Projekte, tsconfig.base.json setzt aber
+    // `declaration: false` + `declarationMap: true` (TS5069).
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": []
   },

--- a/apps/admin-client/tsconfig.spec.json
+++ b/apps/admin-client/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": ["vitest/globals"]
   },

--- a/apps/api-edge/tsconfig.migrations.json
+++ b/apps/api-edge/tsconfig.migrations.json
@@ -6,6 +6,10 @@
     "require": ["tsconfig-paths/register"]
   },
   "compilerOptions": {
+    // Siehe tsconfig.spec.json: `tsc --build --emitDeclarationOnly` laeuft ueber
+    // alle referenzierten Projekte, tsconfig.base.json setzt aber
+    // `declaration: false` + `declarationMap: true` (TS5069).
+    "declaration": true,
     "rootDir": "."
   },
   "files": ["knexfile.ts"],

--- a/apps/api-edge/tsconfig.spec.json
+++ b/apps/api-edge/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/apps/pos-client/tsconfig.app.json
+++ b/apps/pos-client/tsconfig.app.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // Siehe tsconfig.spec.json: `tsc --build --emitDeclarationOnly` laeuft ueber
+    // alle referenzierten Projekte, tsconfig.base.json setzt aber
+    // `declaration: false` + `declarationMap: true` (TS5069).
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": []
   },

--- a/apps/pos-client/tsconfig.spec.json
+++ b/apps/pos-client/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": ["vitest/globals"]
   },

--- a/apps/setup-client/tsconfig.app.json
+++ b/apps/setup-client/tsconfig.app.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // Siehe tsconfig.spec.json: `tsc --build --emitDeclarationOnly` laeuft ueber
+    // alle referenzierten Projekte, tsconfig.base.json setzt aber
+    // `declaration: false` + `declarationMap: true` (TS5069).
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": []
   },

--- a/apps/setup-client/tsconfig.spec.json
+++ b/apps/setup-client/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": ["vitest/globals"]
   },

--- a/libs/apps/pos-client/shell/tsconfig.spec.json
+++ b/libs/apps/pos-client/shell/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/allergens/domain/tsconfig.spec.json
+++ b/libs/domains/allergens/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/apikeys/domain/tsconfig.spec.json
+++ b/libs/domains/apikeys/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/apikeys/domain/vite.config.ts
+++ b/libs/domains/apikeys/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/apikeys/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/audit-events/domain/tsconfig.spec.json
+++ b/libs/domains/audit-events/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/audit-events/domain/vite.config.ts
+++ b/libs/domains/audit-events/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/audit-events/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/auth/data-access/tsconfig.lib.json
+++ b/libs/domains/auth/data-access/tsconfig.lib.json
@@ -9,7 +9,7 @@
     "types": [],
     "paths": {
       "@panary/auth/data-access": [
-        "dist/types/auth-data-access-internal.d.ts"
+        "./dist/types/auth-data-access-internal.d.ts"
       ],
       "@panary/auth/domain": [
         "../domain/dist/index.d.ts"

--- a/libs/domains/auth/domain/tsconfig.spec.json
+++ b/libs/domains/auth/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/auth/domain/vite.config.ts
+++ b/libs/domains/auth/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/auth/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/brands/domain/tsconfig.spec.json
+++ b/libs/domains/brands/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/brands/domain/vite.config.ts
+++ b/libs/domains/brands/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/brands/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/businessdays/aggregator/vite.config.ts
+++ b/libs/domains/businessdays/aggregator/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/businessdays/aggregator',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/cloud-connection/domain/tsconfig.spec.json
+++ b/libs/domains/cloud-connection/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/cloud-connection/domain/vite.config.ts
+++ b/libs/domains/cloud-connection/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/cloud-connection/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/cloud-edges/domain/tsconfig.spec.json
+++ b/libs/domains/cloud-edges/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/cloud-edges/domain/vite.config.ts
+++ b/libs/domains/cloud-edges/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/cloud-edges/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/corporate-customers/domain/tsconfig.spec.json
+++ b/libs/domains/corporate-customers/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/corporate-customers/domain/vite.config.ts
+++ b/libs/domains/corporate-customers/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/corporate-customers/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/customers/domain/tsconfig.spec.json
+++ b/libs/domains/customers/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/customers/domain/vite.config.ts
+++ b/libs/domains/customers/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/customers/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/devices/domain/tsconfig.spec.json
+++ b/libs/domains/devices/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/devices/domain/vite.config.ts
+++ b/libs/domains/devices/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/devices/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/discounts/domain/tsconfig.spec.json
+++ b/libs/domains/discounts/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/discounts/domain/vite.config.ts
+++ b/libs/domains/discounts/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/discounts/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/edge-pairing/domain/tsconfig.spec.json
+++ b/libs/domains/edge-pairing/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/edge-pairing/domain/vite.config.ts
+++ b/libs/domains/edge-pairing/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/edge-pairing/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/ingredients/domain/tsconfig.spec.json
+++ b/libs/domains/ingredients/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/locations/data-access/tsconfig.lib.json
+++ b/libs/domains/locations/data-access/tsconfig.lib.json
@@ -24,7 +24,7 @@
         "../../customers/domain/dist/index.d.ts"
       ],
       "@panary/locations/data-access": [
-        "dist/types/locations-data-access-internal.d.ts"
+        "./dist/types/locations-data-access-internal.d.ts"
       ],
       "@panary/locations/domain": [
         "../domain/dist/index.d.ts"

--- a/libs/domains/locations/domain/tsconfig.spec.json
+++ b/libs/domains/locations/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/locations/domain/vite.config.ts
+++ b/libs/domains/locations/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/locations/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/notifications/domain/tsconfig.spec.json
+++ b/libs/domains/notifications/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/notifications/domain/vite.config.ts
+++ b/libs/domains/notifications/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/notifications/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/opening-hour-exceptions/domain/tsconfig.spec.json
+++ b/libs/domains/opening-hour-exceptions/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/order-interactions/domain/tsconfig.spec.json
+++ b/libs/domains/order-interactions/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/order-interactions/domain/vite.config.ts
+++ b/libs/domains/order-interactions/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/order-interactions/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/orders/data-access/tsconfig.spec.json
+++ b/libs/domains/orders/data-access/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/orders/data-access/vite.config.ts
+++ b/libs/domains/orders/data-access/vite.config.ts
@@ -5,15 +5,15 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/orders/data-access',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   resolve: {
     // Die ng-packagr-`paths` in tsconfig.lib.json zeigen auf dist-`.d.ts`
     // (Build-Typ-Auflösung) — für die Vitest-LAUFZEIT auf die TS-Quellen umbiegen.
     alias: {
-      '@panary/orders/domain': join(import.meta.dirname, '../domain/src/index.ts'),
-      '@panary/shared-common': join(import.meta.dirname, '../../../shared/common/src/index.ts'),
+      '@panary/orders/domain': join(__dirname, '../domain/src/index.ts'),
+      '@panary/shared-common': join(__dirname, '../../../shared/common/src/index.ts'),
     },
   },
   // Uncomment this if you are using workers.

--- a/libs/domains/orders/domain/tsconfig.spec.json
+++ b/libs/domains/orders/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/orders/domain/vite.config.ts
+++ b/libs/domains/orders/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/orders/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/pre-orders/domain/tsconfig.spec.json
+++ b/libs/domains/pre-orders/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/pre-orders/domain/vite.config.ts
+++ b/libs/domains/pre-orders/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/pre-orders/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/pricelists/domain/tsconfig.spec.json
+++ b/libs/domains/pricelists/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/product-groups/domain/tsconfig.spec.json
+++ b/libs/domains/product-groups/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/product-groups/domain/vite.config.ts
+++ b/libs/domains/product-groups/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/product-groups/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/products/data-access/tsconfig.lib.json
+++ b/libs/domains/products/data-access/tsconfig.lib.json
@@ -39,7 +39,7 @@
         "../../product-groups/domain/dist/index.d.ts"
       ],
       "@panary/products/data-access": [
-        "dist/types/products-data-access-internal.d.ts"
+        "./dist/types/products-data-access-internal.d.ts"
       ],
       "@panary/products/domain": [
         "../domain/dist/index.d.ts"

--- a/libs/domains/products/data-access/tsconfig.spec.json
+++ b/libs/domains/products/data-access/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/products/domain/tsconfig.spec.json
+++ b/libs/domains/products/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/products/domain/vite.config.ts
+++ b/libs/domains/products/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/products/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/receipts/domain/tsconfig.spec.json
+++ b/libs/domains/receipts/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/recipes/domain/tsconfig.spec.json
+++ b/libs/domains/recipes/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/reservations/domain/tsconfig.spec.json
+++ b/libs/domains/reservations/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/reservations/domain/vite.config.ts
+++ b/libs/domains/reservations/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/reservations/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/supplier-products/domain/tsconfig.spec.json
+++ b/libs/domains/supplier-products/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/suppliers/domain/tsconfig.spec.json
+++ b/libs/domains/suppliers/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/sync/domain/tsconfig.spec.json
+++ b/libs/domains/sync/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/sync/domain/vite.config.ts
+++ b/libs/domains/sync/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/sync/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/tenants/domain/tsconfig.spec.json
+++ b/libs/domains/tenants/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/tenants/domain/vite.config.ts
+++ b/libs/domains/tenants/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/tenants/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/tse/domain/src/lib/order-signing-flow.spec.ts
+++ b/libs/domains/tse/domain/src/lib/order-signing-flow.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import {
   allocateOrderTransactionNumber,
@@ -15,7 +15,13 @@ import {
 import type { OrderTseInfo } from './order-signing'
 import { TseUnavailableError } from './tse.errors'
 
-const makeLogger = (): TseSigningLogger & { warn: ReturnType<typeof vi.fn> } => ({ warn: vi.fn() })
+// `vi.fn()` ohne Typparameter liefert `Mock<Procedure | Constructable>` — das
+// erfuellt die konkrete `warn`-Signatur des Loggers nicht, die Intersection ist
+// damit unbewohnbar (TS2322). Signatur explizit mitgeben: der Mock bleibt
+// assertierbar UND typkompatibel.
+const makeLogger = (): TseSigningLogger & { warn: Mock<TseSigningLogger['warn']> } => ({
+  warn: vi.fn<TseSigningLogger['warn']>(),
+})
 
 const startedInfo: OrderTseInfo = {
   status: 'started',

--- a/libs/domains/tse/domain/tsconfig.spec.json
+++ b/libs/domains/tse/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/tse/domain/vite.config.ts
+++ b/libs/domains/tse/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/tse/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {

--- a/libs/domains/user-preferences/domain/tsconfig.spec.json
+++ b/libs/domains/user-preferences/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/user-preferences/domain/vite.config.ts
+++ b/libs/domains/user-preferences/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/user-preferences/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/users/data-access/tsconfig.lib.json
+++ b/libs/domains/users/data-access/tsconfig.lib.json
@@ -66,7 +66,7 @@
         "../../user-preferences/domain/dist/index.d.ts"
       ],
       "@panary/users/data-access": [
-        "dist/types/users-data-access-internal.d.ts"
+        "./dist/types/users-data-access-internal.d.ts"
       ],
       "@panary/users/domain": [
         "../domain/dist/index.d.ts"

--- a/libs/domains/users/data-access/tsconfig.spec.json
+++ b/libs/domains/users/data-access/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/users/data-access/vite.config.ts
+++ b/libs/domains/users/data-access/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/users/data-access',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/users/domain/tsconfig.spec.json
+++ b/libs/domains/users/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/users/domain/vite.config.ts
+++ b/libs/domains/users/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/users/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/working-times/domain/tsconfig.spec.json
+++ b/libs/domains/working-times/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/working-times/domain/vite.config.ts
+++ b/libs/domains/working-times/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/working-times/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/domains/write-offs/domain/tsconfig.spec.json
+++ b/libs/domains/write-offs/domain/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/domains/write-offs/domain/vite.config.ts
+++ b/libs/domains/write-offs/domain/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../../node_modules/.vite/libs/domains/write-offs/domain',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/shared/backend/tsconfig.spec.json
+++ b/libs/shared/backend/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/shared/common/tsconfig.spec.json
+++ b/libs/shared/common/tsconfig.spec.json
@@ -1,6 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
+    "module": "esnext",
     "outDir": "../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/shared/common/vite.config.ts
+++ b/libs/shared/common/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../node_modules/.vite/libs/shared/common',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/shared/data-access-updater/tsconfig.spec.json
+++ b/libs/shared/data-access-updater/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/shared/data-access-updater/vite.config.ts
+++ b/libs/shared/data-access-updater/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../node_modules/.vite/libs/shared/data-access-updater',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/shared/data-access/tsconfig.lib.json
+++ b/libs/shared/data-access/tsconfig.lib.json
@@ -46,7 +46,7 @@
         "../common/dist/src/index.d.ts"
       ],
       "@panary/shared/data-access": [
-        "dist/types/shared-data-access-internal.d.ts"
+        "./dist/types/shared-data-access-internal.d.ts"
       ],
       "@panary/shared/data-access-config": [
         "../data-access-config/dist/types/shared-data-access-config-internal.d.ts"

--- a/libs/shared/data-access/tsconfig.spec.json
+++ b/libs/shared/data-access/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },

--- a/libs/shared/data-access/vite.config.ts
+++ b/libs/shared/data-access/vite.config.ts
@@ -4,7 +4,7 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'
 
 export default defineConfig(() => ({
-  root: import.meta.dirname,
+  root: __dirname,
   cacheDir: '../../../node_modules/.vite/libs/shared/data-access',
   plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   // Uncomment this if you are using workers.

--- a/libs/shared/offline-cache/tsconfig.spec.json
+++ b/libs/shared/offline-cache/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `tsc --build --emitDeclarationOnly` (das typecheck-Target des
+    // @nx/js/typescript-Plugins) laeuft ueber ALLE referenzierten Projekte,
+    // also auch ueber dieses. tsconfig.base.json setzt `declaration: false`
+    // und `declarationMap: true` — ohne die folgende Zeile scheitert der
+    // Typecheck mit TS5069, bevor eine einzige Datei geprueft wurde.
+    "declaration": true,
     "outDir": "../../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },


### PR DESCRIPTION
## Problem

`nx run-many -t typecheck` war in **31 von 39 Projekten** kaputt — 14 scheiterten direkt, 17 kamen wegen `dependsOn: ["^typecheck"]` gar nicht erst zur Ausführung. Aufgefallen als Randbefund bei #109.

Vier Ursachen, alle Konfiguration, keine davon ein Code-Regress:

| Fehler | Wo | Ursache |
|---|---|---|
| **TS5069** ×2 pro Projekt | alle 47 `tsconfig.spec.json` | Das typecheck-Target ruft `tsc --build tsconfig.json --emitDeclarationOnly`. Build-Mode läuft über **alle** referenzierten Projekte, also auch über die spec-Config. `tsconfig.base.json` setzt aber `declaration: false` + `declarationMap: true` → Abbruch, bevor eine einzige Datei geprüft ist. Keine der 47 hatte `declaration` oder `composite`. |
| **TS5069** ×2 | 3× `tsconfig.app.json`, 1× `tsconfig.migrations.json` | dieselbe Ursache, andere Dateien |
| **TS1343** | 32× `vite.config.ts` | `root: import.meta.dirname` unter dem `module: commonjs` der Projekt-tsconfig |
| **TS5090** | 5× `tsconfig.lib.json` | `paths`-Selbstreferenz auf `dist/types/<lib>-internal.d.ts` ohne führendes `./`, bei nicht gesetztem `baseUrl` |

Dazu ein echter Typfehler, der erst sichtbar wurde, als der Typecheck die Dateien überhaupt erreichte: **TS2322** in `tse/domain/order-signing-flow.spec.ts` — `TseSigningLogger & { warn: ReturnType<typeof vi.fn> }` verlangt von `warn` gleichzeitig die konkrete Logger-Signatur und den generischen `Mock<Procedure | Constructable>`; die Intersection ist unbewohnbar.

## Lösung

`"declaration": true` in den 52 betroffenen tsconfigs (mit Kommentar, *warum* — die Zeile sieht sonst wie unmotivierter Ballast aus), `./`-Präfix auf den fünf Selbstreferenz-Pfaden, und `vi.fn<TseSigningLogger['warn']>()` im tse-Spec.

Bei den `vite.config.ts` bewusst `__dirname` statt eines Eingriffs in `module`: die aktiv genutzten `vitest.config.mts` derselben Projekte schreiben durchgängig `root: __dirname` (43 Vorkommen gegen 32), Vite shimmt `__dirname` beim Bundeln der Config, und das Root-`package.json` setzt kein `type: module`.

**Verworfen:** `"module": "esnext"` in den spec-Configs. Naheliegend — die spec-Config listet `vitest/importMeta` bereits in `types`, die Absicht war also da. Ausprobiert und wieder zurückgenommen: die geänderte Modulauflösung zieht in fünf Domain-Libs eine **zweite `@sinclair/typebox`-Instanz** herein (96× TS2345 über das `[Kind]`-Symbol). Ein Typecheck-Fix darf keine Modulauflösung verschieben.

## Verifikation

```
nx run-many -t build --skip-nx-cache   → 121 Projekte grün
nx run-many -t test  --skip-nx-cache   →  49 Projekte grün (498 api-edge-Tests)
nx run-many -t typecheck --skip-nx-cache → von 31 auf 6 betroffene Projekte
```

Builds und Tests bewusst ohne Cache, weil die Änderung `tsconfig.app.json`/`tsconfig.lib.json` anfasst — also Configs, die auch Build- und Test-Targets lesen.

## Was bewusst offen bleibt

Zwei Klassen, die keine Konfigurations-Tippfehler sind und je eine eigene Entscheidung brauchen:

1. **96× TS2345 in 5 Domain-Libs** (`orders`, `sync`, `audit-events`, `reservations`, `brands`) — `@feathersjs/typebox@5.0.46` zieht `@sinclair/typebox@0.25.24`, das Root-`package.json` deklariert `^0.34.0`. Die Schemas sind gegen 0.25 typisiert, die Specs importieren `Value`/`FormatRegistry` aus 0.34; das `[Kind]`-Symbol ist nominal verschieden. `@feathersjs/typebox` re-exportiert `Value`/`FormatRegistry` **nicht**, ein Import-Umbau scheidet also aus. Bleiben ein pnpm-`override` oder ein Downgrade der direkten Dependency — beides greift in die Schema-Validierung des gesamten Backends ein und gehört nicht in einen Typecheck-Fix, schon gar nicht ohne Staging-Kanal.

2. **5× TS6306 in `admin-client`** — `tsconfig.app.json` referenziert fünf Lib-Projekte, deren Root-tsconfigs kein `composite: true` tragen. Das nachzuziehen ist eine workspace-weite Umstellung der TS-Solution-Semantik (inkrementelle Builds, `.tsbuildinfo`, striktere `rootDir`-Prüfung), keine Tippfehler-Korrektur.

Beide waren vor diesem PR ebenfalls rot — nur unsichtbar, weil der Typecheck vorher an der Config starb.

## Hinweis

`typecheck` ist **nicht** CI-gated (`nx affected -t lint,test,build`) — dieser PR ändert nichts am CI-Gate, er macht den Befehl nur wieder benutzbar. Getrennt von #109 gehalten, damit dessen Diff im Sync-Nervenzentrum eng bleibt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)