### PR TITLE
fix(security): webpack-dev-middleware auf den Path-Traversal-Fix 7.4.6 heben

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
       "koa@3": "^3.1.2",
       "js-yaml": "^4.3.2",
       "vite": "^7.3.5",
+      "webpack-dev-middleware": "^7.4.6",
       "webpack-dev-server": "^5.2.6",
       "http-proxy-middleware": "^3.0.7",
       "undici": "^7.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,7 @@ overrides:
   koa@3: ^3.1.2
   js-yaml: ^4.3.2
   vite: ^7.3.5
+  webpack-dev-middleware: ^7.4.6
   webpack-dev-server: ^5.2.6
   http-proxy-middleware: ^3.0.7
   undici: ^7.29.0
@@ -9588,8 +9589,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  webpack-dev-middleware@7.4.5:
-    resolution: {integrity: sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==}
+  webpack-dev-middleware@7.4.6:
+    resolution: {integrity: sha512-yBWCMvIfUmuhAE8vdqUKzH0vg9kuWN0KeG4vBnqRplUFHRU7lMQjkiJWxVQzvo2BTewqhPhDlMB41rAt2jVA9A==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       webpack: ^5.0.0
@@ -13747,7 +13748,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+      webpack-dev-middleware: 7.4.6(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -20278,7 +20279,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)):
+  webpack-dev-middleware@7.4.6(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.64.0(tslib@2.8.1)
@@ -20319,7 +20320,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+      webpack-dev-middleware: 7.4.6(tslib@2.8.1)(webpack@5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
       ws: 8.21.3
     optionalDependencies:
       webpack: 5.109.2(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,3 +89,32 @@ trustPolicy: no-downgrade
 # noch fuer Versionen geprueft, die juenger als 30 Tage sind — genau das
 # Zeitfenster, in dem eine Paketuebernahme relevant ist.
 trustPolicyIgnoreAfter: 43200
+
+# --- Befristete Trust-Ausnahmen -------------------------------------------
+# Reife-Datum im Zeilenkommentar, analog zu minimumReleaseAgeExclude oben. Ein
+# Eintrag gehoert nur so lange hierher, wie trustPolicyIgnoreAfter (30 Tage) die
+# Zielversion noch prueft — danach ist er ein stiller Verzicht auf den Check.
+trustPolicyExclude:
+  # webpack-dev-middleware 7.4.6 (publiziert 2026-09-03 13:23 UTC → aus der
+  # 30-Tage-Pruefung ab 2026-10-03 13:23 UTC; dann ENTFERNEN).
+  #
+  # 7.4.6 ist ein Path-Traversal-Fix ("reject requests that resolve outside the
+  # output directory", Containment-Pruefung in getFilenameFromUrl.js) — eine
+  # Variante, die den Fix von GHSA-wr3j-pwj9-hqq6 umgeht: Ohne Trailing-Slash am
+  # publicPath teilt ein Geschwisterpfad wie `/assets../secret` den Prefix, und
+  # der abgeschnittene Rest enthaelt `..`, das aus dem Output-Root ausbricht.
+  # Noch keine CVE/GHSA-ID (Stand 2026-09-11), OSV kennt sie nicht.
+  #
+  # Die trustPolicy blockiert ausgerechnet diesen Fix: Der Maintainer pflegt die
+  # 7.4.x-Linie unveraendert ohne Trusted Publishing (7.4.0-7.4.6, alle von
+  # `evilebottnawi`), waehrend die parallele 8.x-Linie seit 2026-03 ueber GitHub
+  # Actions mit OIDC publiziert. Da trustPolicy nach Publikationsdatum statt nach
+  # semver prueft, gilt 7.4.6 als Downgrade gegenueber 8.3.0 vom selben Tag —
+  # dasselbe Muster wie chokidar@4.0.3, nur mit Sicherheitsrelevanz.
+  #
+  # Ohne diesen Eintrag scheitert jede vollstaendige Neuaufloesung mit
+  # ERR_PNPM_TRUST_DOWNGRADE (so am 2026-09-11 der POS-Release pos-v26.9.1).
+  # Der zugehoerige Override `webpack-dev-middleware: ^7.4.6` in der
+  # package.json ist ZWINGEND: Ohne ihn weicht pnpm still auf 7.4.5 aus — die
+  # verwundbare Version. Beide Teile gehoeren zusammen.
+  - 'webpack-dev-middleware'


### PR DESCRIPTION
- fix(security): webpack-dev-middleware auf den Path-Traversal-Fix 7.4.6 heben
